### PR TITLE
Remove sidebar navigation badges

### DIFF
--- a/src/components/modern-sidebar.tsx
+++ b/src/components/modern-sidebar.tsx
@@ -80,7 +80,6 @@ const generateProjectNavItems = (): NavItem[] => {
     title: project.title,
     icon: getProjectIcon(project.slug, project.title),
     href: `/projects/${project.slug}`,
-    badge: project.status === "in-progress" ? "WIP" : undefined,
   }));
 
   // Add "More" item if there are more projects than featured ones
@@ -105,7 +104,7 @@ const navSections: NavSection[] = [
       { title: "About Me", icon: User, href: "/about" },
       { title: "Models", icon: Bot, href: "/models" },
       { title: "Documentation", icon: BookOpen, href: "/documentation" },
-      { title: "Blog", icon: NotebookPen, href: "/blog/posts", badge: "New" },
+      { title: "Blog", icon: NotebookPen, href: "/blog/posts" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Removed the WIP badges from project links in the sidebar.
- Removed the Blog “New” badge for a cleaner navigation aesthetic.

## Testing
- Not run: existing `npm run lint` script fails because `next lint` is treated as an invalid project directory in this Next setup.