### PR TITLE
BRE-143: Define and validate the canvas operation contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "react-syntax-highlighter": "^15.6.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.6.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -12580,6 +12581,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "tsx --test src/lib/canvas-agent/*.test.ts",
     "lint": "next lint",
     "generate-blog": "tsx scripts/generate-all-blog-posts.ts",
     "fix-blog": "tsx scripts/fix-current-blog.ts"
@@ -45,7 +46,8 @@
     "react-syntax-highlighter": "^15.6.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -2,9 +2,12 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import HomepageWhiteboard from "@/components/homepage-whiteboard";
 
 export default function ExplorePage() {
+  const canvasDebugEnabled =
+    process.env.NODE_ENV !== "production" || process.env.VERCEL_ENV === "preview";
+
   return (
     <>
-      <HomepageWhiteboard />
+      <HomepageWhiteboard canvasDebugEnabled={canvasDebugEnabled} />
       <SpeedInsights />
     </>
   );

--- a/src/components/canvas-contract-lab.module.css
+++ b/src/components/canvas-contract-lab.module.css
@@ -1,0 +1,141 @@
+.lab {
+  --lab-ink: #171714;
+  --lab-paper: #fffdf4;
+  position: absolute;
+  z-index: 40;
+  top: 102px;
+  right: 22px;
+  width: min(410px, calc(100% - 44px));
+  color: var(--lab-ink);
+  filter: drop-shadow(8px 12px 24px rgb(49 42 29 / 18%));
+  font-family: var(--font-satoshi), sans-serif;
+}
+
+.handle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 13px;
+  border: 1px solid rgb(23 23 20 / 72%);
+  border-radius: 4px;
+  color: var(--lab-paper);
+  background: var(--lab-ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.handle span { display: inline-flex; align-items: center; gap: 7px; font-size: .7rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.handle > svg { transition: transform .2s ease; }
+.open .handle > svg { transform: rotate(180deg); }
+
+.body {
+  position: relative;
+  margin-top: -1px;
+  padding: 17px;
+  border: 1px solid rgb(23 23 20 / 35%);
+  border-top: 0;
+  border-radius: 0 0 5px 5px;
+  background-color: var(--lab-paper);
+  background-image: linear-gradient(rgb(29 78 216 / 7%) 1px, transparent 1px);
+  background-size: 100% 24px;
+}
+
+.body::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 32px;
+  border-left: 1px solid rgb(228 87 62 / 22%);
+  pointer-events: none;
+}
+
+.heading,
+.fixtures,
+.editorLabel,
+.body textarea,
+.result,
+.actions { position: relative; z-index: 1; }
+
+.heading { display: flex; align-items: flex-start; justify-content: space-between; padding-left: 27px; }
+.heading span { color: #b54533; font-size: .58rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.heading h2 { margin: 3px 0 0; font-size: 1rem; line-height: 1.05; }
+.heading i { color: #8a857a; font-family: monospace; font-size: .58rem; }
+
+.fixtures { display: flex; flex-wrap: wrap; gap: 5px; margin: 14px 0 11px 27px; }
+.fixtures button {
+  padding: 5px 8px;
+  border: 1px solid rgb(23 23 20 / 18%);
+  border-radius: 3px;
+  color: #5c584f;
+  background: rgb(255 255 255 / 68%);
+  font: inherit;
+  font-size: .62rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.fixtures button:hover,
+.fixtures button:focus-visible { outline: none; border-color: #b54533; color: #b54533; transform: translateY(-1px); }
+
+.editorLabel { display: block; margin: 0 0 5px 27px; color: #777168; font-family: monospace; font-size: .58rem; letter-spacing: .06em; text-transform: uppercase; }
+.body textarea {
+  display: block;
+  width: calc(100% - 27px);
+  height: 210px;
+  margin-left: 27px;
+  resize: vertical;
+  border: 1px solid rgb(23 23 20 / 22%);
+  border-radius: 3px;
+  outline: none;
+  padding: 11px 12px;
+  color: #24231f;
+  background: rgb(255 255 255 / 86%);
+  font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+  tab-size: 2;
+}
+.body textarea:focus { border-color: #1d4ed8; box-shadow: 0 0 0 3px rgb(29 78 216 / 9%); }
+
+.result {
+  display: grid;
+  grid-template-columns: 17px 1fr;
+  gap: 8px;
+  margin: 10px 0 0 27px;
+  padding: 9px 10px;
+  border-left: 3px solid #777168;
+  background: rgb(119 113 104 / 8%);
+}
+.result strong,
+.result span { display: block; }
+.result strong { font-size: .68rem; }
+.result span,
+.result li { color: #68635a; font-size: .61rem; line-height: 1.35; }
+.result ul { margin: 5px 0 0; padding-left: 15px; }
+.success { border-color: #047857; background: rgb(4 120 87 / 8%); }
+.success > svg { color: #047857; }
+.warning { border-color: #a16207; background: rgb(161 98 7 / 9%); }
+.warning > svg { color: #a16207; }
+.error { border-color: #b91c1c; background: rgb(185 28 28 / 8%); }
+.error > svg { color: #b91c1c; }
+
+.actions { display: flex; align-items: center; gap: 7px; margin: 11px 0 0 27px; }
+.actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 11px;
+  border: 1px solid var(--lab-ink);
+  border-radius: 3px;
+  color: var(--lab-paper);
+  background: var(--lab-ink);
+  font: inherit;
+  font-size: .64rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+.actions button:hover { transform: translateY(-1px); }
+.actions button:disabled { opacity: .35; cursor: default; transform: none; }
+.actions .confirm { border-color: #a16207; color: #7c4c08; background: #fef3c7; }
+
+@media (max-width: 720px) {
+  .lab { top: 82px; right: 12px; width: calc(100% - 24px); }
+  .body textarea { height: 170px; }
+}

--- a/src/components/canvas-contract-lab.tsx
+++ b/src/components/canvas-contract-lab.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Braces, Check, ChevronDown, Play, ShieldAlert, X } from "lucide-react";
+import {
+  compileCanvasPatch,
+  validateCanvasPatch,
+  type CanvasPatch,
+  type CanvasPatchContext,
+  type CompiledCanvasPatch,
+} from "@/lib/canvas-agent";
+import type { CanvasSnapshot } from "./excalidraw-canvas";
+import styles from "./canvas-contract-lab.module.css";
+
+type CanvasContractLabProps = {
+  getSnapshot: () => CanvasSnapshot | null;
+  onPatchApplied?: () => void;
+};
+
+type Fixture = "safe" | "confirmation" | "invalid";
+type ResultState = {
+  tone: "neutral" | "success" | "warning" | "error";
+  title: string;
+  detail: string;
+  issues?: string[];
+};
+
+const resultIcon = {
+  neutral: Braces,
+  success: Check,
+  warning: ShieldAlert,
+  error: X,
+} as const;
+
+function samplePatch(fixture: Fixture, context: CanvasPatchContext): unknown {
+  if (fixture === "invalid") {
+    return {
+      version: "1",
+      baseSceneVersion: context.sceneVersion,
+      summary: "This malformed patch must be rejected",
+      operations: [{
+        op: "create",
+        ref: "new:off-canvas-note",
+        element: {
+          kind: "note",
+          box: { x: 900, y: 160, width: 240, height: 180 },
+          text: "I should never reach the canvas",
+        },
+      }],
+    };
+  }
+
+  if (fixture === "confirmation") {
+    return {
+      version: "1",
+      baseSceneVersion: context.sceneVersion,
+      summary: "Attempt an unusually large canvas change",
+      operations: [{
+        op: "create",
+        ref: "new:large-change",
+        element: {
+          kind: "note",
+          box: { x: 150, y: 140, width: 700, height: 680 },
+          text: "This patch is valid, but its footprint requires human confirmation.",
+          style: { theme: "warning", fill: "hachure", weight: "bold" },
+        },
+      }],
+    };
+  }
+
+  return {
+    version: "1",
+    baseSceneVersion: context.sceneVersion,
+    summary: "Render a safe model-to-canvas handoff",
+    operations: [
+      {
+        op: "create",
+        ref: "new:model-output",
+        element: {
+          kind: "note",
+          box: { x: 70, y: 250, width: 230, height: 220 },
+          text: "Model JSON\n(untrusted)",
+          style: { theme: "info", fill: "solid", weight: "bold" },
+        },
+      },
+      {
+        op: "create",
+        ref: "new:contract-gate",
+        element: {
+          kind: "ellipse",
+          box: { x: 370, y: 250, width: 240, height: 220 },
+          text: "Validated patch\n(bounded + typed)",
+          style: { theme: "success", fill: "solid", weight: "bold" },
+        },
+      },
+      {
+        op: "connect",
+        ref: "new:validation-arrow",
+        from: "new:model-output",
+        to: "new:contract-gate",
+        label: "validate → compile",
+        style: { theme: "accent", stroke: "dashed", weight: "bold" },
+      },
+    ],
+  } satisfies CanvasPatch;
+}
+
+export default function CanvasContractLab({
+  getSnapshot,
+  onPatchApplied,
+}: CanvasContractLabProps) {
+  const [visible, setVisible] = useState(false);
+  const [open, setOpen] = useState(true);
+  const [source, setSource] = useState("");
+  const [pendingPatch, setPendingPatch] = useState<CompiledCanvasPatch | null>(null);
+  const [result, setResult] = useState<ResultState>({
+    tone: "neutral",
+    title: "Awaiting a fixture",
+    detail: "Load a sample to exercise the model operation boundary.",
+  });
+
+  useEffect(() => {
+    setVisible(new URLSearchParams(window.location.search).get("canvasDebug") === "1");
+  }, []);
+
+  const ResultIcon = resultIcon[result.tone];
+  if (!visible) return null;
+
+  const getContext = () => getSnapshot()?.getPatchContext() ?? null;
+
+  const loadFixture = (fixture: Fixture) => {
+    const context = getContext();
+    if (!context) {
+      setResult({
+        tone: "error",
+        title: "Canvas unavailable",
+        detail: "Wait for Excalidraw to finish opening, then try again.",
+      });
+      return;
+    }
+
+    setSource(JSON.stringify(samplePatch(fixture, context), null, 2));
+    setPendingPatch(null);
+    onPatchApplied?.();
+    setResult({
+      tone: "neutral",
+      title: `${fixture[0].toUpperCase()}${fixture.slice(1)} fixture loaded`,
+      detail: `Bound to ${context.sceneVersion}. Run it when ready.`,
+    });
+  };
+
+  const applyPatch = async (patch: CompiledCanvasPatch, confirmed = false) => {
+    const response = await getSnapshot()?.applyCompiledPatch(patch, { confirmed });
+    if (!response || response.status === "unavailable") {
+      setResult({
+        tone: "error",
+        title: "Canvas unavailable",
+        detail: "The patch was valid, but Excalidraw was not ready to apply it.",
+      });
+      return;
+    }
+
+    if (response.status === "confirmation-required") {
+      setPendingPatch(patch);
+      setResult({
+        tone: "warning",
+        title: "Human confirmation required",
+        detail: `Blocked before mutation: ${response.reasons.join(", ")}.`,
+      });
+      return;
+    }
+
+    setPendingPatch(null);
+    setResult({
+      tone: "success",
+      title: "Patch applied as one action",
+      detail: `${response.elementIds.length} model-authored elements reached the canvas. Use Excalidraw Undo to reverse them together.`,
+    });
+  };
+
+  const runPatch = async () => {
+    const context = getContext();
+    if (!context) {
+      setResult({
+        tone: "error",
+        title: "Canvas unavailable",
+        detail: "Wait for Excalidraw to finish opening, then try again.",
+      });
+      return;
+    }
+
+    let input: unknown;
+    try {
+      input = JSON.parse(source);
+    } catch (error) {
+      setResult({
+        tone: "error",
+        title: "Invalid JSON",
+        detail: error instanceof Error ? error.message : "The fixture could not be parsed.",
+      });
+      return;
+    }
+
+    const validation = validateCanvasPatch(input, context);
+    if (!validation.ok) {
+      setPendingPatch(null);
+      setResult({
+        tone: "error",
+        title: "Rejected before canvas access",
+        detail: "The contract stopped this payload without changing the scene.",
+        issues: validation.issues,
+      });
+      return;
+    }
+
+    const compiled = compileCanvasPatch(
+      validation.value.patch,
+      context,
+      validation.value.risk,
+    );
+    await applyPatch(compiled);
+  };
+
+  return (
+    <aside className={`${styles.lab} ${open ? styles.open : ""}`} aria-label="Canvas contract lab">
+      <button
+        className={styles.handle}
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        aria-label={open ? "Collapse canvas contract lab" : "Open canvas contract lab"}
+      >
+        <span><Braces size={15} /> contract lab</span>
+        <ChevronDown size={15} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className={styles.body}>
+          <div className={styles.heading}>
+            <div>
+              <span>BRE-143 · debug only</span>
+              <h2>Model operation boundary</h2>
+            </div>
+            <i>01 / validate</i>
+          </div>
+
+          <div className={styles.fixtures} aria-label="Contract fixtures">
+            <button type="button" onClick={() => loadFixture("safe")}>safe apply</button>
+            <button type="button" onClick={() => loadFixture("confirmation")}>needs approval</button>
+            <button type="button" onClick={() => loadFixture("invalid")}>invalid payload</button>
+          </div>
+
+          <label className={styles.editorLabel} htmlFor="canvas-contract-json">
+            model-shaped JSON
+          </label>
+          <textarea
+            id="canvas-contract-json"
+            value={source}
+            onChange={(event) => {
+              setSource(event.target.value);
+              setPendingPatch(null);
+            }}
+            placeholder="Load a fixture or paste a CanvasPatch…"
+            spellCheck={false}
+          />
+
+          <div className={`${styles.result} ${styles[result.tone]}`} role="status" aria-live="polite">
+            <ResultIcon size={16} />
+            <div>
+              <strong>{result.title}</strong>
+              <span>{result.detail}</span>
+              {result.issues && (
+                <ul>{result.issues.map((issue) => <li key={issue}>{issue}</li>)}</ul>
+              )}
+            </div>
+          </div>
+
+          <div className={styles.actions}>
+            <button type="button" onClick={runPatch} disabled={!source.trim()}>
+              <Play size={14} fill="currentColor" /> validate + run
+            </button>
+            {pendingPatch && (
+              <button
+                type="button"
+                className={styles.confirm}
+                onClick={() => applyPatch(pendingPatch, true)}
+              >
+                confirm mutation
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/excalidraw-canvas.tsx
+++ b/src/components/excalidraw-canvas.tsx
@@ -11,7 +11,10 @@ import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
 import type { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/data/transform";
 import {
   applyCompiledPatchToElements,
+  NORMALIZED_CANVAS_SIZE,
   type CompiledCanvasPatch,
+  type CanvasContextElement,
+  type CanvasPatchContext,
 } from "@/lib/canvas-agent";
 import "@excalidraw/excalidraw/index.css";
 import styles from "./excalidraw-canvas.module.css";
@@ -71,6 +74,7 @@ export type CanvasSnapshot = {
     elements: ExcalidrawElementSkeleton[],
   ) => Promise<readonly ExcalidrawElement[]>;
   removeElements: (elementIds: readonly string[]) => void;
+  getPatchContext: () => CanvasPatchContext | null;
   applyCompiledPatch: (
     patch: CompiledCanvasPatch,
     options?: { confirmed?: boolean },
@@ -94,8 +98,67 @@ const emptySnapshot: CanvasSnapshot = {
   captureCanvasImage: async () => null,
   insertElements: async () => [],
   removeElements: () => undefined,
+  getPatchContext: () => null,
   applyCompiledPatch: async () => ({ status: "unavailable" }),
 };
+
+function sceneVersion(elements: readonly ExcalidrawElement[]) {
+  let hash = 2_166_136_261;
+  const signature = elements
+    .map((element) => `${element.id}:${element.version}:${element.versionNonce}`)
+    .join("|");
+
+  for (let index = 0; index < signature.length; index += 1) {
+    hash ^= signature.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+
+  return `scene-${(hash >>> 0).toString(36)}`;
+}
+
+function contextKind(element: ExcalidrawElement): CanvasContextElement["kind"] | null {
+  switch (element.type) {
+    case "text":
+    case "rectangle":
+    case "ellipse":
+    case "frame":
+    case "arrow":
+      return element.type;
+    case "freedraw":
+      return "freehand";
+    default:
+      return null;
+  }
+}
+
+function normalizedBox(
+  element: ExcalidrawElement,
+  bounds: CanvasPatchContext["bounds"],
+): CanvasContextElement["box"] | null {
+  const rawX = Math.round(((element.x - bounds.x) / bounds.width) * NORMALIZED_CANVAS_SIZE);
+  const rawY = Math.round(((element.y - bounds.y) / bounds.height) * NORMALIZED_CANVAS_SIZE);
+  const rawWidth = Math.round((element.width / bounds.width) * NORMALIZED_CANVAS_SIZE);
+  const rawHeight = Math.round((element.height / bounds.height) * NORMALIZED_CANVAS_SIZE);
+
+  if (
+    rawX >= NORMALIZED_CANVAS_SIZE ||
+    rawY >= NORMALIZED_CANVAS_SIZE ||
+    rawX + rawWidth <= 0 ||
+    rawY + rawHeight <= 0
+  ) {
+    return null;
+  }
+
+  const x = Math.max(0, rawX);
+  const y = Math.max(0, rawY);
+  const width = Math.max(10, Math.min(NORMALIZED_CANVAS_SIZE - x, rawWidth));
+  const height = Math.max(10, Math.min(NORMALIZED_CANVAS_SIZE - y, rawHeight));
+  if (x + width > NORMALIZED_CANVAS_SIZE || y + height > NORMALIZED_CANVAS_SIZE) {
+    return null;
+  }
+
+  return { x, y, width, height };
+}
 
 export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
@@ -199,6 +262,45 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
     api.setToast({ message: "Cleared the agent's sketch", duration: 1800 });
   }, []);
 
+  const getPatchContext = useCallback((): CanvasPatchContext | null => {
+    const { elements, appState } = sceneRef.current;
+    if (!appState) return null;
+
+    const zoom = Math.max(0.01, appState.zoom.value);
+    const bounds = {
+      x: -appState.scrollX,
+      y: -appState.scrollY,
+      width: Math.max(1, appState.width / zoom),
+      height: Math.max(1, appState.height / zoom),
+    };
+    const contextElements = elements.flatMap<CanvasContextElement>((element) => {
+      const kind = contextKind(element);
+      const box = normalizedBox(element, bounds);
+      if (!kind || !box) return [];
+
+      const customData = element.customData as Record<string, unknown> | undefined;
+      const declaredOrigin = customData?.origin;
+      const origin =
+        declaredOrigin === "agent" || declaredOrigin === "system"
+          ? declaredOrigin
+          : "visitor";
+
+      return [{
+        ref: `existing:${element.id.replace(/[^a-z0-9_-]/gi, "-").toLowerCase()}`,
+        elementId: element.id,
+        kind,
+        box,
+        origin,
+      }];
+    });
+
+    return {
+      sceneVersion: sceneVersion(elements),
+      bounds,
+      elements: contextElements,
+    };
+  }, []);
+
   const applyCompiledPatch = useCallback(
     async (
       patch: CompiledCanvasPatch,
@@ -232,6 +334,16 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
         captureUpdate: CaptureUpdateAction.IMMEDIATELY,
       });
       api.setActiveTool({ type: "selection" });
+      if (createdElements.length > 0) {
+        api.scrollToContent(createdElements, {
+          fitToViewport: true,
+          viewportZoomFactor: 0.78,
+          animate: true,
+          duration: 420,
+          maxZoom: 1.1,
+          canvasOffsets: { top: 70, bottom: 150 },
+        });
+      }
       api.setToast({ message: "Applied the agent's canvas update", duration: 2200 });
 
       return {
@@ -272,10 +384,11 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
         captureCanvasImage,
         insertElements,
         removeElements,
+        getPatchContext,
         applyCompiledPatch,
       });
     },
-    [applyCompiledPatch, captureCanvasImage, insertElements, publishSnapshot, removeElements],
+    [applyCompiledPatch, captureCanvasImage, getPatchContext, insertElements, publishSnapshot, removeElements],
   );
 
   return (
@@ -289,6 +402,7 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
             captureCanvasImage,
             insertElements,
             removeElements,
+            getPatchContext,
             applyCompiledPatch,
           });
         }}

--- a/src/components/excalidraw-canvas.tsx
+++ b/src/components/excalidraw-canvas.tsx
@@ -9,6 +9,10 @@ import type {
 } from "@excalidraw/excalidraw/types";
 import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
 import type { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/data/transform";
+import {
+  applyCompiledPatchToElements,
+  type CompiledCanvasPatch,
+} from "@/lib/canvas-agent";
 import "@excalidraw/excalidraw/index.css";
 import styles from "./excalidraw-canvas.module.css";
 
@@ -67,7 +71,16 @@ export type CanvasSnapshot = {
     elements: ExcalidrawElementSkeleton[],
   ) => Promise<readonly ExcalidrawElement[]>;
   removeElements: (elementIds: readonly string[]) => void;
+  applyCompiledPatch: (
+    patch: CompiledCanvasPatch,
+    options?: { confirmed?: boolean },
+  ) => Promise<CanvasPatchApplyResult>;
 };
+
+export type CanvasPatchApplyResult =
+  | { status: "applied"; elementIds: string[] }
+  | { status: "confirmation-required"; reasons: string[] }
+  | { status: "unavailable" };
 
 type ExcalidrawCanvasProps = {
   onSnapshot?: (snapshot: CanvasSnapshot) => void;
@@ -81,6 +94,7 @@ const emptySnapshot: CanvasSnapshot = {
   captureCanvasImage: async () => null,
   insertElements: async () => [],
   removeElements: () => undefined,
+  applyCompiledPatch: async () => ({ status: "unavailable" }),
 };
 
 export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) {
@@ -185,6 +199,49 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
     api.setToast({ message: "Cleared the agent's sketch", duration: 1800 });
   }, []);
 
+  const applyCompiledPatch = useCallback(
+    async (
+      patch: CompiledCanvasPatch,
+      options: { confirmed?: boolean } = {},
+    ): Promise<CanvasPatchApplyResult> => {
+      const api = apiRef.current;
+      if (!api) return { status: "unavailable" };
+
+      if (patch.risk.requiresConfirmation && !options.confirmed) {
+        return {
+          status: "confirmation-required",
+          reasons: patch.risk.reasons,
+        };
+      }
+
+      const { CaptureUpdateAction, convertToExcalidrawElements } = await import(
+        "@excalidraw/excalidraw"
+      );
+      const createdElements = convertToExcalidrawElements(patch.createElements, {
+        regenerateIds: false,
+      });
+      const nextElements = applyCompiledPatchToElements(
+        api.getSceneElements(),
+        createdElements,
+        patch,
+      );
+
+      // One captured scene update makes the accepted patch one undoable action.
+      api.updateScene({
+        elements: nextElements,
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+      api.setActiveTool({ type: "selection" });
+      api.setToast({ message: "Applied the agent's canvas update", duration: 2200 });
+
+      return {
+        status: "applied",
+        elementIds: createdElements.map((element) => element.id),
+      };
+    },
+    [],
+  );
+
   const handleChange = useCallback(
     (
       elements: readonly ExcalidrawElement[],
@@ -215,9 +272,10 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
         captureCanvasImage,
         insertElements,
         removeElements,
+        applyCompiledPatch,
       });
     },
-    [captureCanvasImage, insertElements, publishSnapshot, removeElements],
+    [applyCompiledPatch, captureCanvasImage, insertElements, publishSnapshot, removeElements],
   );
 
   return (
@@ -231,6 +289,7 @@ export default function ExcalidrawCanvas({ onSnapshot }: ExcalidrawCanvasProps) 
             captureCanvasImage,
             insertElements,
             removeElements,
+            applyCompiledPatch,
           });
         }}
         initialData={{

--- a/src/components/homepage-whiteboard.tsx
+++ b/src/components/homepage-whiteboard.tsx
@@ -16,6 +16,7 @@ import type { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/data/tran
 import { projects } from "@/data/projects";
 import { lukesFont, satoshi } from "@/app/fonts";
 import ExcalidrawCanvas, { type CanvasSnapshot } from "./excalidraw-canvas";
+import CanvasContractLab from "./canvas-contract-lab";
 import styles from "./homepage-whiteboard.module.css";
 
 type AgentState = "loading" | "idle" | "thinking" | "active" | "error";
@@ -466,7 +467,13 @@ const buildMalcomFollowUp = (
   ];
 };
 
-export default function HomepageWhiteboard() {
+type HomepageWhiteboardProps = {
+  canvasDebugEnabled?: boolean;
+};
+
+export default function HomepageWhiteboard({
+  canvasDebugEnabled = false,
+}: HomepageWhiteboardProps) {
   const [agentState, setAgentState] = useState<AgentState>("loading");
   const [prompt, setPrompt] = useState("");
   const [question, setQuestion] = useState("");
@@ -477,6 +484,7 @@ export default function HomepageWhiteboard() {
   const usedMalcomFollowUps = useRef<Set<string>>(new Set());
   const [malcomShowcase, setMalcomShowcase] = useState(false);
   const [completedFollowUps, setCompletedFollowUps] = useState<string[]>([]);
+  const [contractLabActive, setContractLabActive] = useState(false);
 
   const handleSnapshot = useCallback((snapshot: CanvasSnapshot) => {
     canvasSnapshot.current = snapshot;
@@ -575,6 +583,13 @@ export default function HomepageWhiteboard() {
       <section className={styles.canvas} aria-label="Luke's project exploration canvas">
         <ExcalidrawCanvas onSnapshot={handleSnapshot} />
 
+        {canvasDebugEnabled && (
+          <CanvasContractLab
+            getSnapshot={() => canvasSnapshot.current}
+            onPatchApplied={() => setContractLabActive(true)}
+          />
+        )}
+
         {agentState === "loading" && (
           <div className={styles.loading} role="status">
             <span className={styles.agentGlyph}>✦</span>
@@ -583,7 +598,9 @@ export default function HomepageWhiteboard() {
           </div>
         )}
 
-        {(agentState === "idle" || agentState === "error") && turn.current === 0 && (
+        {(agentState === "idle" || agentState === "error") &&
+          turn.current === 0 &&
+          !contractLabActive && (
           <div className={styles.invitation}>
             <div className={`${styles.eyebrow} ${lukesFont.className}`}>
               <PencilLine size={17} /> pick a thread or write your own

--- a/src/lib/canvas-agent/apply.ts
+++ b/src/lib/canvas-agent/apply.ts
@@ -1,0 +1,101 @@
+import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
+import type { CompiledCanvasPatch, CompiledElementUpdate } from "./compiler";
+
+export function applyCompiledPatchToElements(
+  sceneElements: readonly ExcalidrawElement[],
+  createdElements: readonly ExcalidrawElement[],
+  compiled: CompiledCanvasPatch,
+): ExcalidrawElement[] {
+  const elements = new Map(
+    [...sceneElements, ...createdElements].map((element) => [element.id, element]),
+  );
+
+  for (const update of compiled.updates) {
+    const element = elements.get(update.elementId);
+    if (!element) continue;
+
+    elements.set(update.elementId, applyElementUpdate(element, update));
+
+    if (update.text !== undefined && element.type !== "text") {
+      const boundTextId = element.boundElements?.find((bound) => bound.type === "text")?.id;
+      const boundText = boundTextId ? elements.get(boundTextId) : undefined;
+      if (boundText?.type === "text") {
+        elements.set(boundText.id, {
+          ...boundText,
+          text: update.text,
+          originalText: update.text,
+        });
+      }
+    }
+  }
+
+  for (const group of compiled.groups) {
+    for (const elementId of group.elementIds) {
+      const element = elements.get(elementId);
+      if (!element) continue;
+      elements.set(elementId, {
+        ...element,
+        groupIds: [group.groupId, ...element.groupIds.filter((id) => id !== group.groupId)],
+      });
+    }
+  }
+
+  for (const connection of compiled.connections) {
+    const arrow = elements.get(connection.arrowId);
+    const from = elements.get(connection.fromElementId);
+    const to = elements.get(connection.toElementId);
+    if (arrow?.type !== "arrow" || !from || !to) continue;
+
+    elements.set(arrow.id, {
+      ...arrow,
+      startBinding: { elementId: from.id, focus: 0, gap: 8 },
+      endBinding: { elementId: to.id, focus: 0, gap: 8 },
+    });
+    elements.set(from.id, addBoundArrow(from, arrow.id));
+    elements.set(to.id, addBoundArrow(to, arrow.id));
+  }
+
+  for (const elementId of compiled.deleteElementIds) {
+    const element = elements.get(elementId);
+    if (!element) continue;
+    elements.set(elementId, { ...element, isDeleted: true });
+
+    for (const bound of element.boundElements ?? []) {
+      if (bound.type !== "text") continue;
+      const boundText = elements.get(bound.id);
+      if (boundText) elements.set(bound.id, { ...boundText, isDeleted: true });
+    }
+  }
+
+  return [...elements.values()];
+}
+
+function addBoundArrow(element: ExcalidrawElement, arrowId: string): ExcalidrawElement {
+  if (element.boundElements?.some((bound) => bound.id === arrowId)) return element;
+  return {
+    ...element,
+    boundElements: [...(element.boundElements ?? []), { id: arrowId, type: "arrow" }],
+  };
+}
+
+function applyElementUpdate(
+  element: ExcalidrawElement,
+  update: CompiledElementUpdate,
+): ExcalidrawElement {
+  const next = {
+    ...element,
+    ...(update.x === undefined ? {} : { x: update.x }),
+    ...(update.y === undefined ? {} : { y: update.y }),
+    ...(update.style === undefined ? {} : update.style),
+  } as ExcalidrawElement;
+
+  if (update.text !== undefined && next.type === "text") {
+    return {
+      ...next,
+      text: update.text,
+      originalText: update.text,
+    };
+  }
+
+  return next;
+}

--- a/src/lib/canvas-agent/canvas-agent.test.ts
+++ b/src/lib/canvas-agent/canvas-agent.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
+import {
+  applyCompiledPatchToElements,
+  canvasPatchJsonSchema,
+  compileCanvasPatch,
+  validateCanvasPatch,
+  type CanvasPatch,
+  type CanvasPatchContext,
+} from "./index";
+
+const context: CanvasPatchContext = {
+  sceneVersion: "scene-v1",
+  bounds: { x: 100, y: 200, width: 2_000, height: 1_000 },
+  elements: [
+    {
+      ref: "existing:controller",
+      elementId: "controller-id",
+      kind: "rectangle",
+      box: { x: 50, y: 100, width: 180, height: 120 },
+      origin: "agent",
+    },
+    {
+      ref: "existing:visitor-note",
+      elementId: "visitor-note-id",
+      kind: "note",
+      box: { x: 700, y: 650, width: 180, height: 120 },
+      origin: "visitor",
+    },
+  ],
+};
+
+const validPatch = {
+  version: "1",
+  baseSceneVersion: "scene-v1",
+  summary: "Add and connect a policy gate",
+  operations: [
+    {
+      op: "create",
+      ref: "new:policy-gate",
+      element: {
+        kind: "note",
+        box: { x: 350, y: 220, width: 220, height: 150 },
+        text: "Policy gate",
+        style: { theme: "warning", fill: "solid", weight: "bold" },
+      },
+    },
+    {
+      op: "connect",
+      ref: "new:controller-policy-arrow",
+      from: "existing:controller",
+      to: "new:policy-gate",
+      label: "checks scope",
+      style: { theme: "success", stroke: "dashed" },
+    },
+    {
+      op: "update",
+      target: "new:policy-gate",
+      text: "Policy gate\ncredentials · scope · approval",
+    },
+    {
+      op: "move",
+      target: "new:policy-gate",
+      to: { x: 400, y: 250 },
+    },
+    {
+      op: "group",
+      groupRef: "new:policy-cluster",
+      members: ["new:policy-gate", "new:controller-policy-arrow"],
+    },
+    {
+      op: "create",
+      ref: "new:underline",
+      element: {
+        kind: "freehand",
+        points: [
+          { x: 420, y: 420 },
+          { x: 480, y: 430 },
+          { x: 540, y: 418 },
+        ],
+        style: { theme: "accent", weight: "bold" },
+      },
+    },
+  ],
+} satisfies CanvasPatch;
+
+test("exports a provider-compatible JSON schema", () => {
+  assert.equal(canvasPatchJsonSchema.type, "object");
+  assert.ok(canvasPatchJsonSchema.properties);
+});
+
+test("validates a complete semantic patch", () => {
+  const result = validateCanvasPatch(validPatch, context);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.value.risk.requiresConfirmation, false);
+});
+
+test("rejects unknown fields and out-of-bounds boxes at runtime", () => {
+  const malformed = clone(validPatch);
+  Object.assign(malformed.operations[0], { surprise: true });
+  Object.assign((malformed.operations[0] as { element: { box: object } }).element.box, {
+    x: 900,
+    width: 200,
+  });
+
+  const result = validateCanvasPatch(malformed, context);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.issues.some((issue) => issue.includes("Unrecognized key")));
+  assert.ok(result.issues.some((issue) => issue.includes("normalized canvas width")));
+});
+
+test("rejects references before they are available", () => {
+  const patch = clone(validPatch) as unknown as {
+    operations: Array<Record<string, unknown>>;
+  };
+  patch.operations[1] = {
+    op: "connect",
+    ref: "new:bad-arrow",
+    from: "existing:controller",
+    to: "new:not-created",
+  };
+
+  const result = validateCanvasPatch(patch, context);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.issues.includes("operations[1] references unavailable element new:not-created"));
+});
+
+test("rejects duplicate model-authored aliases", () => {
+  const patch = clone(validPatch) as unknown as {
+    operations: Array<Record<string, unknown>>;
+  };
+  patch.operations[5].ref = "new:policy-gate";
+
+  const result = validateCanvasPatch(patch, context);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.issues.includes("operations[5] declares duplicate ref new:policy-gate"));
+});
+
+test("requires confirmation for deletes and visitor-authored changes", () => {
+  const patch: CanvasPatch = {
+    version: "1",
+    baseSceneVersion: "scene-v1",
+    summary: "Remove the visitor note",
+    operations: [
+      {
+        op: "delete",
+        target: "existing:visitor-note",
+        reason: "The visitor explicitly asked to remove it",
+      },
+    ],
+  };
+
+  const result = validateCanvasPatch(patch, context);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.value.risk.reasons, ["delete", "visitor-authored-change"]);
+  assert.equal(result.value.risk.requiresConfirmation, true);
+});
+
+test("requires confirmation for stale or unusually large patches", () => {
+  const patch: CanvasPatch = {
+    version: "1",
+    baseSceneVersion: "older-scene",
+    summary: "Fill the board",
+    operations: [
+      {
+        op: "create",
+        ref: "new:large-one",
+        element: { kind: "rectangle", box: { x: 0, y: 0, width: 700, height: 700 } },
+      },
+      {
+        op: "create",
+        ref: "new:large-two",
+        element: { kind: "ellipse", box: { x: 200, y: 200, width: 700, height: 700 } },
+      },
+    ],
+  };
+
+  const result = validateCanvasPatch(patch, context);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.value.risk.reasons, ["stale-scene", "large-created-area"]);
+});
+
+test("compiles the same patch deterministically into scene coordinates", () => {
+  const result = validateCanvasPatch(validPatch, context);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  const first = compileCanvasPatch(result.value.patch, context, result.value.risk);
+  const second = compileCanvasPatch(result.value.patch, context, result.value.risk);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.createElements.length, 3);
+  assert.equal(first.groups.length, 1);
+  assert.equal(first.connections.length, 1);
+  assert.equal(first.deleteElementIds.length, 0);
+  assert.equal(first.elementIdsByRef["existing:controller"], "controller-id");
+  assert.match(first.elementIdsByRef["new:policy-gate"], /^agent-/);
+
+  const note = first.createElements[0];
+  assert.equal(note.x, 800);
+  assert.equal(note.y, 420);
+  assert.equal(note.width, 440);
+  assert.equal(note.height, 150);
+});
+
+test("compiles every supported create element kind", () => {
+  const patch: CanvasPatch = {
+    version: "1",
+    baseSceneVersion: "scene-v1",
+    summary: "Exercise the element vocabulary",
+    operations: [
+      {
+        op: "create",
+        ref: "new:text",
+        element: { kind: "text", box: { x: 10, y: 10, width: 150, height: 60 }, text: "Heading" },
+      },
+      {
+        op: "create",
+        ref: "new:rectangle",
+        element: { kind: "rectangle", box: { x: 200, y: 10, width: 150, height: 100 } },
+      },
+      {
+        op: "create",
+        ref: "new:ellipse",
+        element: { kind: "ellipse", box: { x: 400, y: 10, width: 150, height: 100 } },
+      },
+      {
+        op: "create",
+        ref: "new:frame",
+        element: { kind: "frame", box: { x: 10, y: 200, width: 500, height: 300 }, label: "System" },
+      },
+      {
+        op: "create",
+        ref: "new:arrow",
+        element: { kind: "arrow", points: [{ x: 100, y: 600 }, { x: 450, y: 700 }] },
+      },
+    ],
+  };
+
+  const result = validateCanvasPatch(patch, context);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  const compiled = compileCanvasPatch(result.value.patch, context, result.value.risk);
+  assert.deepEqual(
+    compiled.createElements.map((element) => element.type),
+    ["text", "rectangle", "ellipse", "frame", "arrow"],
+  );
+});
+
+test("applies connection bindings to existing and created elements", () => {
+  const result = validateCanvasPatch(validPatch, context);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  const compiled = compileCanvasPatch(result.value.patch, context, result.value.risk);
+  const policyId = compiled.elementIdsByRef["new:policy-gate"];
+  const arrowId = compiled.elementIdsByRef["new:controller-policy-arrow"];
+  const scene = [fakeElement("controller-id", "rectangle")];
+  const created = [
+    fakeElement(policyId, "rectangle"),
+    fakeElement(arrowId, "arrow"),
+    fakeElement(compiled.elementIdsByRef["new:underline"], "freedraw"),
+  ];
+
+  const applied = applyCompiledPatchToElements(scene, created, compiled);
+  const arrow = applied.find((element) => element.id === arrowId);
+  const controller = applied.find((element) => element.id === "controller-id");
+  const policy = applied.find((element) => element.id === policyId);
+
+  assert.equal(arrow?.type, "arrow");
+  if (arrow?.type === "arrow") {
+    assert.equal(arrow.startBinding?.elementId, "controller-id");
+    assert.equal(arrow.endBinding?.elementId, policyId);
+  }
+  assert.ok(controller?.boundElements?.some((bound) => bound.id === arrowId));
+  assert.ok(policy?.boundElements?.some((bound) => bound.id === arrowId));
+});
+
+test("rejects patches that exceed the aggregate text budget", () => {
+  const patch: CanvasPatch = {
+    version: "1",
+    baseSceneVersion: "scene-v1",
+    summary: "Oversized text",
+    operations: Array.from({ length: 6 }, (_, index) => ({
+      op: "update" as const,
+      target: "existing:controller" as const,
+      text: `${index}${"x".repeat(499)}`,
+    })),
+  };
+
+  const result = validateCanvasPatch(patch, context);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.ok(result.issues.some((issue) => issue.includes("character budget")));
+});
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function fakeElement(id: string, type: "rectangle" | "arrow" | "freedraw"): ExcalidrawElement {
+  return {
+    id,
+    type,
+    x: 0,
+    y: 0,
+    groupIds: [],
+    boundElements: null,
+    isDeleted: false,
+  } as unknown as ExcalidrawElement;
+}

--- a/src/lib/canvas-agent/compiler.ts
+++ b/src/lib/canvas-agent/compiler.ts
@@ -1,0 +1,402 @@
+import type { ExcalidrawElementSkeleton } from "@excalidraw/excalidraw/data/transform";
+import type { ExcalidrawFreeDrawElement } from "@excalidraw/excalidraw/element/types";
+import type {
+  CanvasElementRef,
+  CanvasElementSpec,
+  CanvasPatch,
+  CanvasStyle,
+  NewCanvasElementRef,
+  NormalizedBox,
+  NormalizedPoint,
+} from "./contract";
+import type { CanvasPatchContext, CanvasPatchRisk } from "./validation";
+
+type CompiledStyle = {
+  strokeColor: string;
+  backgroundColor: string;
+  fillStyle: "solid" | "hachure";
+  strokeStyle: "solid" | "dashed" | "dotted";
+  strokeWidth: number;
+  opacity: number;
+};
+
+export type CompiledElementUpdate = {
+  elementId: string;
+  x?: number;
+  y?: number;
+  text?: string;
+  style?: CompiledStyle;
+};
+
+export type CompiledElementGroup = {
+  groupId: string;
+  elementIds: string[];
+};
+
+export type CompiledElementConnection = {
+  arrowId: string;
+  fromElementId: string;
+  toElementId: string;
+};
+
+export type CompiledCanvasPatch = {
+  patchKey: string;
+  createElements: ExcalidrawElementSkeleton[];
+  updates: CompiledElementUpdate[];
+  groups: CompiledElementGroup[];
+  connections: CompiledElementConnection[];
+  deleteElementIds: string[];
+  elementIdsByRef: Record<string, string>;
+  risk: CanvasPatchRisk;
+};
+
+type ResolvedElement = {
+  id: string;
+  kind: CanvasElementSpec["kind"];
+  box: NormalizedBox;
+};
+
+const THEME_COLORS = {
+  ink: { stroke: "#20201d", fill: "#f4f0e7" },
+  muted: { stroke: "#6f6a61", fill: "#ebe6dc" },
+  accent: { stroke: "#c83f2f", fill: "#fee2e2" },
+  info: { stroke: "#1d4ed8", fill: "#dbeafe" },
+  success: { stroke: "#047857", fill: "#d1fae5" },
+  warning: { stroke: "#a16207", fill: "#fef3c7" },
+  danger: { stroke: "#b91c1c", fill: "#fee2e2" },
+} as const;
+
+export function compileCanvasPatch(
+  patch: CanvasPatch,
+  context: CanvasPatchContext,
+  risk: CanvasPatchRisk,
+): CompiledCanvasPatch {
+  const patchKey = stableId("canvas-patch", JSON.stringify(patch));
+  const resolved = new Map<CanvasElementRef, ResolvedElement>(
+    context.elements.map((element) => [
+      element.ref,
+      { id: element.elementId, kind: element.kind, box: element.box },
+    ]),
+  );
+  const createElements: ExcalidrawElementSkeleton[] = [];
+  const updates: CompiledElementUpdate[] = [];
+  const groups: CompiledElementGroup[] = [];
+  const connections: CompiledElementConnection[] = [];
+  const deleteElementIds: string[] = [];
+  const elementIdsByRef: Record<string, string> = Object.fromEntries(
+    [...resolved].map(([ref, value]) => [ref, value.id]),
+  );
+
+  patch.operations.forEach((operation) => {
+    switch (operation.op) {
+      case "create": {
+        const id = stableId(patchKey, operation.ref);
+        const compiled = compileCreateElement(id, operation.ref, operation.element, context);
+        createElements.push(compiled);
+        const box = getElementBox(operation.element);
+        resolved.set(operation.ref, { id, kind: operation.element.kind, box });
+        elementIdsByRef[operation.ref] = id;
+        break;
+      }
+      case "update": {
+        const target = requireResolved(operation.target, resolved);
+        updates.push({
+          elementId: target.id,
+          ...(operation.text === undefined ? {} : { text: operation.text }),
+          ...(operation.style === undefined ? {} : { style: compileStyle(operation.style) }),
+        });
+        break;
+      }
+      case "move": {
+        const target = requireResolved(operation.target, resolved);
+        const position = normalizedToScene(operation.to, context);
+        updates.push({ elementId: target.id, x: position.x, y: position.y });
+        resolved.set(operation.target, {
+          ...target,
+          box: { ...target.box, x: operation.to.x, y: operation.to.y },
+        });
+        break;
+      }
+      case "group": {
+        groups.push({
+          groupId: stableId(patchKey, operation.groupRef),
+          elementIds: operation.members.map((ref) => requireResolved(ref, resolved).id),
+        });
+        break;
+      }
+      case "connect": {
+        const from = requireResolved(operation.from, resolved);
+        const to = requireResolved(operation.to, resolved);
+        const id = stableId(patchKey, operation.ref);
+        const start = boxCenter(from.box);
+        const end = boxCenter(to.box);
+        const startScene = normalizedToScene(start, context);
+        const endScene = normalizedToScene(end, context);
+        const style = compileStyle(operation.style);
+
+        createElements.push({
+          id,
+          type: "arrow",
+          x: startScene.x,
+          y: startScene.y,
+          width: round(endScene.x - startScene.x),
+          height: round(endScene.y - startScene.y),
+          points: [[0, 0], [round(endScene.x - startScene.x), round(endScene.y - startScene.y)]],
+          endArrowhead: "arrow",
+          roughness: 1,
+          ...style,
+          ...(operation.label === undefined
+            ? {}
+            : { label: { text: operation.label, fontFamily: 1, fontSize: 16 } }),
+          customData: { canvasAgentRef: operation.ref, canvasAgentPatch: patchKey },
+        });
+        connections.push({
+          arrowId: id,
+          fromElementId: from.id,
+          toElementId: to.id,
+        });
+
+        const box = pointsBox([start, end]);
+        resolved.set(operation.ref, { id, kind: "arrow", box });
+        elementIdsByRef[operation.ref] = id;
+        break;
+      }
+      case "delete":
+        deleteElementIds.push(requireResolved(operation.target, resolved).id);
+        break;
+      default:
+        operation satisfies never;
+    }
+
+  });
+
+  return {
+    patchKey,
+    createElements,
+    updates,
+    groups,
+    connections,
+    deleteElementIds,
+    elementIdsByRef,
+    risk,
+  };
+}
+
+function compileCreateElement(
+  id: string,
+  ref: NewCanvasElementRef,
+  element: CanvasElementSpec,
+  context: CanvasPatchContext,
+): ExcalidrawElementSkeleton {
+  const style = compileStyle(element.style, element.kind === "note" ? "warning" : "ink");
+  const customData = { canvasAgentRef: ref, origin: "agent", canvasAgentVersion: 1 };
+
+  if (element.kind === "arrow") {
+    const [first, ...remaining] = element.points;
+    const origin = normalizedToScene(first, context);
+    const points = [first, ...remaining].map((point) => {
+      const scene = normalizedToScene(point, context);
+      return [round(scene.x - origin.x), round(scene.y - origin.y)] as [number, number];
+    });
+    return {
+      id,
+      type: "arrow",
+      x: origin.x,
+      y: origin.y,
+      points,
+      endArrowhead: "arrow",
+      roughness: 1,
+      ...style,
+      ...(element.label === undefined
+        ? {}
+        : { label: { text: element.label, fontFamily: 1, fontSize: 16 } }),
+      customData,
+    };
+  }
+
+  if (element.kind === "freehand") {
+    return compileFreehand(id, element.points, style, customData, context);
+  }
+
+  const box = normalizedBoxToScene(element.box, context);
+
+  if (element.kind === "text") {
+    return {
+      id,
+      type: "text",
+      ...box,
+      text: element.text,
+      fontFamily: 1,
+      fontSize: 18,
+      textAlign: "left",
+      verticalAlign: "top",
+      strokeColor: style.strokeColor,
+      opacity: style.opacity,
+      customData,
+    };
+  }
+
+  if (element.kind === "frame") {
+    return {
+      id,
+      type: "frame",
+      ...box,
+      children: [],
+      name: element.label,
+      roughness: 1,
+      ...style,
+      customData,
+    };
+  }
+
+  return {
+    id,
+    type: element.kind === "note" ? "rectangle" : element.kind,
+    ...box,
+    roughness: 1,
+    roundness: element.kind === "rectangle" || element.kind === "note" ? { type: 3 } : undefined,
+    ...style,
+    ...(element.text === undefined
+      ? {}
+      : {
+          label: {
+            text: element.text,
+            fontFamily: 1,
+            fontSize: 17,
+            textAlign: "left",
+            verticalAlign: "middle",
+          },
+        }),
+    customData,
+  };
+}
+
+function compileFreehand(
+  id: string,
+  normalizedPoints: readonly NormalizedPoint[],
+  style: CompiledStyle,
+  customData: Record<string, unknown>,
+  context: CanvasPatchContext,
+): ExcalidrawElementSkeleton {
+  const scenePoints = normalizedPoints.map((point) => normalizedToScene(point, context));
+  const minX = Math.min(...scenePoints.map((point) => point.x));
+  const minY = Math.min(...scenePoints.map((point) => point.y));
+  const maxX = Math.max(...scenePoints.map((point) => point.x));
+  const maxY = Math.max(...scenePoints.map((point) => point.y));
+  const seed = stableHash(id) || 1;
+
+  const freehand = {
+    id,
+    type: "freedraw",
+    x: round(minX),
+    y: round(minY),
+    width: round(Math.max(1, maxX - minX)),
+    height: round(Math.max(1, maxY - minY)),
+    points: scenePoints.map((point) => [round(point.x - minX), round(point.y - minY)]),
+    pressures: [],
+    simulatePressure: true,
+    lastCommittedPoint: null,
+    strokeColor: style.strokeColor,
+    backgroundColor: "transparent",
+    fillStyle: "solid",
+    strokeWidth: style.strokeWidth,
+    strokeStyle: style.strokeStyle,
+    roundness: null,
+    roughness: 1,
+    opacity: style.opacity,
+    angle: 0,
+    seed,
+    version: 1,
+    versionNonce: seed,
+    index: null,
+    isDeleted: false,
+    groupIds: [],
+    frameId: null,
+    boundElements: null,
+    updated: 0,
+    link: null,
+    locked: false,
+    customData,
+  } as unknown as ExcalidrawFreeDrawElement;
+
+  return freehand;
+}
+
+function compileStyle(style?: CanvasStyle, defaultTheme: keyof typeof THEME_COLORS = "ink"): CompiledStyle {
+  const theme = THEME_COLORS[style?.theme ?? defaultTheme];
+  return {
+    strokeColor: theme.stroke,
+    backgroundColor: style?.fill === "transparent" ? "transparent" : theme.fill,
+    fillStyle: style?.fill === "hachure" ? "hachure" : "solid",
+    strokeStyle: style?.stroke ?? "solid",
+    strokeWidth: style?.weight === "thin" ? 1 : style?.weight === "bold" ? 4 : 2,
+    opacity: style?.opacity ?? 100,
+  };
+}
+
+function requireResolved(
+  ref: CanvasElementRef,
+  resolved: ReadonlyMap<CanvasElementRef, ResolvedElement>,
+): ResolvedElement {
+  const element = resolved.get(ref);
+  if (!element) throw new Error(`Canvas patch referenced unresolved element ${ref}`);
+  return element;
+}
+
+function getElementBox(element: CanvasElementSpec): NormalizedBox {
+  return "box" in element ? element.box : pointsBox(element.points);
+}
+
+function pointsBox(points: readonly NormalizedPoint[]): NormalizedBox {
+  const minX = Math.min(...points.map((point) => point.x));
+  const minY = Math.min(...points.map((point) => point.y));
+  const maxX = Math.max(...points.map((point) => point.x));
+  const maxY = Math.max(...points.map((point) => point.y));
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(10, maxX - minX),
+    height: Math.max(10, maxY - minY),
+  };
+}
+
+function boxCenter(box: NormalizedBox): NormalizedPoint {
+  return {
+    x: Math.round(box.x + box.width / 2),
+    y: Math.round(box.y + box.height / 2),
+  };
+}
+
+function normalizedBoxToScene(box: NormalizedBox, context: CanvasPatchContext) {
+  const topLeft = normalizedToScene({ x: box.x, y: box.y }, context);
+  return {
+    x: topLeft.x,
+    y: topLeft.y,
+    width: round((box.width / 1000) * context.bounds.width),
+    height: round((box.height / 1000) * context.bounds.height),
+  };
+}
+
+function normalizedToScene(point: NormalizedPoint, context: CanvasPatchContext) {
+  return {
+    x: round(context.bounds.x + (point.x / 1000) * context.bounds.width),
+    y: round(context.bounds.y + (point.y / 1000) * context.bounds.height),
+  };
+}
+
+function stableId(namespace: string, value: string): string {
+  return `agent-${stableHash(`${namespace}:${value}`).toString(36)}`;
+}
+
+function stableHash(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/src/lib/canvas-agent/contract.ts
+++ b/src/lib/canvas-agent/contract.ts
@@ -1,0 +1,178 @@
+import { z } from "zod";
+
+export const CANVAS_PATCH_VERSION = "1" as const;
+export const NORMALIZED_CANVAS_SIZE = 1000;
+export const MAX_PATCH_OPERATIONS = 25;
+export const MAX_PATCH_TEXT_LENGTH = 2_500;
+export const MAX_FREEHAND_POINTS = 128;
+
+const normalizedCoordinateSchema = z.number().int().min(0).max(NORMALIZED_CANVAS_SIZE);
+const normalizedSizeSchema = z.number().int().min(10).max(NORMALIZED_CANVAS_SIZE);
+const aliasNameSchema = z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/);
+
+export const existingElementRefSchema = z.templateLiteral([
+  z.literal("existing:"),
+  aliasNameSchema,
+]);
+export const newElementRefSchema = z.templateLiteral([
+  z.literal("new:"),
+  aliasNameSchema,
+]);
+export const elementRefSchema = z.union([existingElementRefSchema, newElementRefSchema]);
+
+export const normalizedPointSchema = z.strictObject({
+  x: normalizedCoordinateSchema,
+  y: normalizedCoordinateSchema,
+});
+
+export const normalizedBoxSchema = z
+  .strictObject({
+    x: normalizedCoordinateSchema,
+    y: normalizedCoordinateSchema,
+    width: normalizedSizeSchema,
+    height: normalizedSizeSchema,
+  })
+  .refine((box) => box.x + box.width <= NORMALIZED_CANVAS_SIZE, {
+    message: "box must fit within the normalized canvas width",
+    path: ["width"],
+  })
+  .refine((box) => box.y + box.height <= NORMALIZED_CANVAS_SIZE, {
+    message: "box must fit within the normalized canvas height",
+    path: ["height"],
+  });
+
+export const canvasThemeSchema = z.enum([
+  "ink",
+  "muted",
+  "accent",
+  "info",
+  "success",
+  "warning",
+  "danger",
+]);
+
+export const canvasStyleSchema = z.strictObject({
+  theme: canvasThemeSchema.optional(),
+  fill: z.enum(["transparent", "solid", "hachure"]).optional(),
+  stroke: z.enum(["solid", "dashed", "dotted"]).optional(),
+  weight: z.enum(["thin", "regular", "bold"]).optional(),
+  opacity: z.number().int().min(20).max(100).optional(),
+});
+
+const shortTextSchema = z.string().trim().min(1).max(500);
+const labelSchema = z.string().trim().min(1).max(160);
+
+const boxedElementSchema = z.strictObject({
+  kind: z.enum(["note", "rectangle", "ellipse"]),
+  box: normalizedBoxSchema,
+  text: shortTextSchema.optional(),
+  style: canvasStyleSchema.optional(),
+});
+
+const textElementSchema = z.strictObject({
+  kind: z.literal("text"),
+  box: normalizedBoxSchema,
+  text: shortTextSchema,
+  style: canvasStyleSchema.optional(),
+});
+
+const frameElementSchema = z.strictObject({
+  kind: z.literal("frame"),
+  box: normalizedBoxSchema,
+  label: labelSchema.optional(),
+  style: canvasStyleSchema.optional(),
+});
+
+const arrowElementSchema = z.strictObject({
+  kind: z.literal("arrow"),
+  points: z.array(normalizedPointSchema).min(2).max(12),
+  label: labelSchema.optional(),
+  style: canvasStyleSchema.optional(),
+});
+
+const freehandElementSchema = z.strictObject({
+  kind: z.literal("freehand"),
+  points: z.array(normalizedPointSchema).min(2).max(MAX_FREEHAND_POINTS),
+  style: canvasStyleSchema.optional(),
+});
+
+export const canvasElementSpecSchema = z.discriminatedUnion("kind", [
+  boxedElementSchema,
+  textElementSchema,
+  frameElementSchema,
+  arrowElementSchema,
+  freehandElementSchema,
+]);
+
+const createOperationSchema = z.strictObject({
+  op: z.literal("create"),
+  ref: newElementRefSchema,
+  element: canvasElementSpecSchema,
+});
+
+const updateOperationSchema = z
+  .strictObject({
+    op: z.literal("update"),
+    target: elementRefSchema,
+    text: shortTextSchema.optional(),
+    style: canvasStyleSchema.optional(),
+  })
+  .refine((operation) => operation.text !== undefined || operation.style !== undefined, {
+    message: "update must include text or style",
+  });
+
+const moveOperationSchema = z.strictObject({
+  op: z.literal("move"),
+  target: elementRefSchema,
+  to: normalizedPointSchema,
+});
+
+const groupOperationSchema = z.strictObject({
+  op: z.literal("group"),
+  groupRef: newElementRefSchema,
+  members: z.array(elementRefSchema).min(2).max(20),
+});
+
+const connectOperationSchema = z.strictObject({
+  op: z.literal("connect"),
+  ref: newElementRefSchema,
+  from: elementRefSchema,
+  to: elementRefSchema,
+  label: labelSchema.optional(),
+  style: canvasStyleSchema.optional(),
+});
+
+const deleteOperationSchema = z.strictObject({
+  op: z.literal("delete"),
+  target: elementRefSchema,
+  reason: z.string().trim().min(1).max(240),
+});
+
+export const canvasOperationSchema = z.discriminatedUnion("op", [
+  createOperationSchema,
+  updateOperationSchema,
+  moveOperationSchema,
+  groupOperationSchema,
+  connectOperationSchema,
+  deleteOperationSchema,
+]);
+
+export const canvasPatchSchema = z.strictObject({
+  version: z.literal(CANVAS_PATCH_VERSION),
+  baseSceneVersion: z.string().trim().min(1).max(128),
+  summary: z.string().trim().min(1).max(300),
+  operations: z.array(canvasOperationSchema).min(1).max(MAX_PATCH_OPERATIONS),
+});
+
+export const canvasPatchJsonSchema = z.toJSONSchema(canvasPatchSchema, {
+  target: "draft-2020-12",
+});
+
+export type CanvasPatch = z.infer<typeof canvasPatchSchema>;
+export type CanvasOperation = z.infer<typeof canvasOperationSchema>;
+export type CanvasElementSpec = z.infer<typeof canvasElementSpecSchema>;
+export type CanvasStyle = z.infer<typeof canvasStyleSchema>;
+export type CanvasElementRef = z.infer<typeof elementRefSchema>;
+export type NewCanvasElementRef = z.infer<typeof newElementRefSchema>;
+export type NormalizedPoint = z.infer<typeof normalizedPointSchema>;
+export type NormalizedBox = z.infer<typeof normalizedBoxSchema>;

--- a/src/lib/canvas-agent/index.ts
+++ b/src/lib/canvas-agent/index.ts
@@ -1,0 +1,36 @@
+export {
+  CANVAS_PATCH_VERSION,
+  MAX_FREEHAND_POINTS,
+  MAX_PATCH_OPERATIONS,
+  MAX_PATCH_TEXT_LENGTH,
+  NORMALIZED_CANVAS_SIZE,
+  canvasPatchJsonSchema,
+  canvasPatchSchema,
+  type CanvasElementRef,
+  type CanvasElementSpec,
+  type CanvasOperation,
+  type CanvasPatch,
+  type CanvasStyle,
+  type NewCanvasElementRef,
+  type NormalizedBox,
+  type NormalizedPoint,
+} from "./contract";
+export {
+  classifyCanvasPatchRisk,
+  validateCanvasPatch,
+  type CanvasContextElement,
+  type CanvasElementOrigin,
+  type CanvasPatchContext,
+  type CanvasPatchRisk,
+  type CanvasPatchRiskReason,
+  type CanvasPatchValidationResult,
+  type ValidatedCanvasPatch,
+} from "./validation";
+export {
+  compileCanvasPatch,
+  type CompiledCanvasPatch,
+  type CompiledElementConnection,
+  type CompiledElementGroup,
+  type CompiledElementUpdate,
+} from "./compiler";
+export { applyCompiledPatchToElements } from "./apply";

--- a/src/lib/canvas-agent/validation.ts
+++ b/src/lib/canvas-agent/validation.ts
@@ -1,0 +1,237 @@
+import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
+import {
+  MAX_PATCH_TEXT_LENGTH,
+  canvasPatchSchema,
+  type CanvasElementRef,
+  type CanvasOperation,
+  type CanvasPatch,
+  type NormalizedBox,
+} from "./contract";
+
+export type CanvasElementOrigin = "visitor" | "agent" | "system";
+
+export type CanvasContextElement = {
+  ref: `existing:${string}`;
+  elementId: ExcalidrawElement["id"];
+  kind: "text" | "note" | "rectangle" | "ellipse" | "frame" | "arrow" | "freehand";
+  box: NormalizedBox;
+  origin: CanvasElementOrigin;
+};
+
+export type CanvasPatchContext = {
+  sceneVersion: string;
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  elements: readonly CanvasContextElement[];
+};
+
+export type CanvasPatchRiskReason =
+  | "stale-scene"
+  | "delete"
+  | "visitor-authored-change"
+  | "large-operation-count"
+  | "large-created-area"
+  | "large-move";
+
+export type CanvasPatchRisk = {
+  requiresConfirmation: boolean;
+  reasons: CanvasPatchRiskReason[];
+};
+
+export type ValidatedCanvasPatch = {
+  patch: CanvasPatch;
+  risk: CanvasPatchRisk;
+};
+
+export type CanvasPatchValidationResult =
+  | { ok: true; value: ValidatedCanvasPatch }
+  | { ok: false; issues: string[] };
+
+const LARGE_OPERATION_COUNT = 12;
+const LARGE_CREATED_AREA = 450_000;
+const LARGE_MOVE_DISTANCE = 450;
+
+export function validateCanvasPatch(
+  input: unknown,
+  context: CanvasPatchContext,
+): CanvasPatchValidationResult {
+  const parsed = canvasPatchSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      issues: parsed.error.issues.map(formatSchemaIssue),
+    };
+  }
+
+  const patch = parsed.data;
+  const issues = validateSemantics(patch, context);
+  if (issues.length > 0) return { ok: false, issues };
+
+  return {
+    ok: true,
+    value: {
+      patch,
+      risk: classifyCanvasPatchRisk(patch, context),
+    },
+  };
+}
+
+export function classifyCanvasPatchRisk(
+  patch: CanvasPatch,
+  context: CanvasPatchContext,
+): CanvasPatchRisk {
+  const reasons = new Set<CanvasPatchRiskReason>();
+  const contextByRef = new Map(context.elements.map((element) => [element.ref, element]));
+
+  if (patch.baseSceneVersion !== context.sceneVersion) reasons.add("stale-scene");
+  if (patch.operations.length > LARGE_OPERATION_COUNT) reasons.add("large-operation-count");
+
+  let createdArea = 0;
+
+  for (const operation of patch.operations) {
+    if (operation.op === "create" && "box" in operation.element) {
+      createdArea += operation.element.box.width * operation.element.box.height;
+    }
+
+    if (operation.op === "delete") reasons.add("delete");
+
+    for (const target of getMutationTargets(operation)) {
+      const existing = contextByRef.get(target as CanvasContextElement["ref"]);
+      if (existing?.origin === "visitor") reasons.add("visitor-authored-change");
+
+      if (operation.op === "move" && existing) {
+        const distance = Math.hypot(operation.to.x - existing.box.x, operation.to.y - existing.box.y);
+        if (distance > LARGE_MOVE_DISTANCE) reasons.add("large-move");
+      }
+    }
+  }
+
+  if (createdArea > LARGE_CREATED_AREA) reasons.add("large-created-area");
+
+  return {
+    requiresConfirmation: reasons.size > 0,
+    reasons: [...reasons],
+  };
+}
+
+function validateSemantics(patch: CanvasPatch, context: CanvasPatchContext): string[] {
+  const issues: string[] = [];
+  const existingRefs = new Set(context.elements.map((element) => element.ref));
+  const availableRefs = new Set<CanvasElementRef>(existingRefs);
+  const declaredRefs = new Set<string>(existingRefs);
+  let totalTextLength = patch.summary.length;
+
+  if (!Number.isFinite(context.bounds.x) || !Number.isFinite(context.bounds.y)) {
+    issues.push("context bounds origin must be finite");
+  }
+  if (!Number.isFinite(context.bounds.width) || context.bounds.width <= 0) {
+    issues.push("context bounds width must be positive and finite");
+  }
+  if (!Number.isFinite(context.bounds.height) || context.bounds.height <= 0) {
+    issues.push("context bounds height must be positive and finite");
+  }
+
+  patch.operations.forEach((operation, index) => {
+    for (const ref of getDeclaredRefs(operation)) {
+      if (declaredRefs.has(ref)) {
+        issues.push(`operations[${index}] declares duplicate ref ${ref}`);
+      } else {
+        declaredRefs.add(ref);
+      }
+    }
+
+    for (const ref of getReferencedRefs(operation)) {
+      if (!availableRefs.has(ref)) {
+        issues.push(`operations[${index}] references unavailable element ${ref}`);
+      }
+    }
+
+    for (const ref of getDeclaredElementRefs(operation)) availableRefs.add(ref);
+    totalTextLength += getOperationTextLength(operation);
+  });
+
+  if (totalTextLength > MAX_PATCH_TEXT_LENGTH) {
+    issues.push(`patch text exceeds the ${MAX_PATCH_TEXT_LENGTH} character budget`);
+  }
+
+  return issues;
+}
+
+function getDeclaredRefs(operation: CanvasOperation): string[] {
+  switch (operation.op) {
+    case "create":
+    case "connect":
+      return [operation.ref];
+    case "group":
+      return [operation.groupRef];
+    default:
+      return [];
+  }
+}
+
+function getDeclaredElementRefs(operation: CanvasOperation): CanvasElementRef[] {
+  return operation.op === "create" || operation.op === "connect" ? [operation.ref] : [];
+}
+
+function getReferencedRefs(operation: CanvasOperation): CanvasElementRef[] {
+  switch (operation.op) {
+    case "update":
+    case "move":
+    case "delete":
+      return [operation.target];
+    case "group":
+      return operation.members;
+    case "connect":
+      return [operation.from, operation.to];
+    default:
+      return [];
+  }
+}
+
+function getMutationTargets(operation: CanvasOperation): CanvasElementRef[] {
+  switch (operation.op) {
+    case "update":
+    case "move":
+    case "delete":
+      return [operation.target];
+    case "group":
+      return operation.members;
+    default:
+      return [];
+  }
+}
+
+function getOperationTextLength(operation: CanvasOperation): number {
+  switch (operation.op) {
+    case "create":
+      switch (operation.element.kind) {
+        case "text":
+        case "note":
+        case "rectangle":
+        case "ellipse":
+          return operation.element.text?.length ?? 0;
+        case "frame":
+        case "arrow":
+          return operation.element.label?.length ?? 0;
+        case "freehand":
+          return 0;
+      }
+    case "update":
+      return operation.text?.length ?? 0;
+    case "connect":
+      return operation.label?.length ?? 0;
+    case "delete":
+      return operation.reason.length;
+    default:
+      return 0;
+  }
+}
+
+function formatSchemaIssue(issue: { path: PropertyKey[]; message: string }): string {
+  const path = issue.path.length > 0 ? issue.path.join(".") : "patch";
+  return `${path}: ${issue.message}`;
+}


### PR DESCRIPTION
## Summary

- define provider-neutral CanvasPatchV1 operations with strict Zod runtime and JSON Schema output
- validate normalized geometry, sequential references, aliases, aggregate budgets, and scene context
- classify stale, destructive, visitor-authored, large-area, and large-move patches for confirmation
- deterministically compile semantic operations into Excalidraw skeletons, updates, groups, bindings, and deletions
- apply accepted patches through one captured Excalidraw scene update so the full patch remains undoable
- add a preview/local-only contract lab at `/explore?canvasDebug=1` with safe, confirmation-required, and invalid fixtures
- derive live scene versions and normalized viewport context for future model requests

## Validation

- `npm test` — 11 passing
- `npx tsc --noEmit`
- `npm run build`
- Playwright: safe patch applied, invalid payload rejected without mutation, risky patch blocked until confirmation, two patches undone as two atomic actions
- browser console: 0 errors, 0 warnings

## Scope

This PR establishes the provider-neutral contract, canvas application seam, and gated manual acceptance harness only. Gemini request handling remains in BRE-144; public quota/bot controls remain in BRE-147; browser-local WebLLM evaluation is tracked in BRE-150.