### PR TITLE
BRE-145: Curated agent knowledge packs for featured projects

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -3,5 +3,6 @@
 Before extending the vision-agent canvas, read:
 
 - [BRE-143 Canvas Operation Contract Handoff](docs/handoffs/BRE-143-canvas-operation-contract.md) — branch location, contract boundary, debug harness, verification recipe, and implementation gotchas.
+- [BRE-145 Curated Agent Knowledge Packs Handoff](docs/handoffs/BRE-145-knowledge-packs.md) — authored per-project knowledge packs, lazy-selection loader, dev-only viewer, and opt-in Malcolm chat ingestion script.
 
 The canvas implementation currently lives on the long-lived `homepage-canvas` integration branch rather than `main`.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,7 @@
+# Agent Handoffs
+
+Before extending the vision-agent canvas, read:
+
+- [BRE-143 Canvas Operation Contract Handoff](docs/handoffs/BRE-143-canvas-operation-contract.md) — branch location, contract boundary, debug harness, verification recipe, and implementation gotchas.
+
+The canvas implementation currently lives on the long-lived `homepage-canvas` integration branch rather than `main`.

--- a/docs/handoffs/BRE-143-canvas-operation-contract.md
+++ b/docs/handoffs/BRE-143-canvas-operation-contract.md
@@ -1,0 +1,128 @@
+# BRE-143 Canvas Operation Contract Handoff
+
+Last updated: 2026-07-14
+
+## Where the implementation lives
+
+BRE-143 was implemented in PR [#25](https://github.com/lukebrevoort/website/pull/25) and squash-merged into the long-lived `homepage-canvas` integration branch at commit `92d5676c1acf1037271658d52c105ada7c010129`.
+
+The implementation is intentionally **not on `main` yet**. Repository guidance routes canvas tickets through `homepage-canvas` until the complete canvas experience is ready for promotion. Start future canvas-agent work from an up-to-date `homepage-canvas`, not from `main`.
+
+Key implementation files on `homepage-canvas`:
+
+- `src/lib/canvas-agent/contract.ts`: strict Zod `CanvasPatchV1` contract and JSON Schema.
+- `src/lib/canvas-agent/validation.ts`: semantic validation and confirmation risk classification.
+- `src/lib/canvas-agent/compiler.ts`: deterministic semantic-patch to Excalidraw compilation.
+- `src/lib/canvas-agent/apply.ts`: immutable updates, grouping, connections, and deletion application.
+- `src/components/excalidraw-canvas.tsx`: live scene context, confirmation boundary, and atomic scene update.
+- `src/components/canvas-contract-lab.tsx`: preview/local-only manual acceptance harness.
+
+## What BRE-143 does and does not prove
+
+The ticket proves that untrusted, model-shaped JSON can be validated, risk-classified, compiled deterministically, and applied as one undoable Excalidraw action. It does not call Gemini, inspect screenshots with a model, enforce public quotas, or choose between Gemini and WebLLM.
+
+Follow-up ownership remains:
+
+- BRE-144: Gemini request and vision-model integration.
+- BRE-147: public quota, abuse, and bot controls.
+- BRE-150: browser-local WebLLM feasibility/fallback spike.
+
+Do not bypass the contract from a provider adapter. The provider should produce `CanvasPatchV1`; validation and risk confirmation must happen before `applyCompiledPatch` mutates the scene.
+
+## Manual contract lab
+
+The diagnostic drawer is available at:
+
+```text
+/explore?canvasDebug=1
+```
+
+It is gated twice:
+
+1. The component is only included during local development or a Vercel Preview build.
+2. The drawer only appears when `canvasDebug=1` is present.
+
+It should not appear on a production Vercel deployment, even with the query parameter. The drawer includes three fixtures:
+
+- `safe apply`: validates, compiles, and applies model-authored shapes and a connection.
+- `needs approval`: remains blocked with `large-created-area` until `confirm mutation` is clicked.
+- `invalid payload`: rejects an out-of-bounds box without changing the scene.
+
+After accepted fixtures, Excalidraw Undo should reverse each accepted patch as one action.
+
+## Gotchas encountered
+
+### Excalidraw counts are not operation counts
+
+A semantic note or labeled connector can compile into multiple Excalidraw elements because bound text and labels are separate scene elements. The safe fixture has three semantic operations but reports six created elements. Assert scene behavior and stable IDs; do not assume one operation equals one Excalidraw element.
+
+### Confirmation is a two-step application flow
+
+`applyCompiledPatch(patch)` returns `confirmation-required` for risky patches without mutating the canvas. After explicit approval, call the same compiled patch with `{ confirmed: true }`. Recompiling after scene state changes can change the scene version or coordinate context.
+
+### Scene versions are intentionally live
+
+The canvas gateway hashes active Excalidraw element IDs and versions. Fixtures are bound to the current scene when loaded. If the scene changes before Run, the patch becomes stale and correctly requires confirmation. Provider requests should capture context and submit against that exact `baseSceneVersion`.
+
+### Coordinates are viewport-normalized
+
+The provider contract uses a `0..1000` normalized visible-canvas coordinate system. `getPatchContext()` derives visible scene bounds from Excalidraw scroll and zoom state. Avoid sending raw screen pixels or assuming a fixed desktop canvas size.
+
+### Vercel previews are authentication-protected
+
+Opening an immutable preview URL in a clean Playwright session redirects to Vercel login. Use an authenticated browser session or Vercel's temporary share/access URL, then retain the resulting cookie while navigating to `/explore?canvasDebug=1`.
+
+### Preview gating is evaluated at build time
+
+The server page enables the lab when `NODE_ENV !== "production"` or `VERCEL_ENV === "preview"`. A local `next build && next start` behaves like production and hides the drawer; use `npm run dev` for local harness checks. A Vercel Preview build exposes it.
+
+### Builds modify generated tracked files
+
+`npm run build`, `npm run dev`, and `npx tsc --noEmit` can modify `next-env.d.ts` and `tsconfig.tsbuildinfo`. Playwright CLI also creates `.playwright-cli/`. Restore or exclude those incidental files before committing. Stage source paths explicitly rather than using `git add -A`.
+
+### Wait for the exact preview commit
+
+The Vercel build took roughly one minute after the push. Confirm the deployment metadata references the expected head SHA before testing or merging. A green older branch preview is not evidence for the latest commit.
+
+## Verification recipe
+
+From a branch containing the BRE-143 implementation:
+
+```bash
+npm test
+npx tsc --noEmit
+npm run build
+```
+
+Expected contract suite: 11 passing tests.
+
+For browser acceptance, run local development and open the gated route:
+
+```bash
+npm run dev
+```
+
+Then validate all three fixtures and confirm:
+
+- the invalid fixture leaves the mark count unchanged;
+- the risky fixture does not mutate before approval;
+- accepted patches add editable native Excalidraw objects;
+- one Undo reverses one accepted patch;
+- the browser console has no application errors.
+
+Always inspect the screenshot rather than trusting command success alone. In the first pass, the normal Explore invitation remained over the generated fixture; the final implementation hides that invitation after a lab patch succeeds so the result is visually inspectable.
+
+## Recommended next integration step
+
+BRE-144 should reuse the same sequence exercised by the lab:
+
+```text
+capture image + CanvasPatchContext
+  -> request structured CanvasPatchV1 from Gemini
+  -> validateCanvasPatch
+  -> compileCanvasPatch
+  -> show confirmation when required
+  -> applyCompiledPatch
+```
+
+Keep the diagnostic fixtures available on preview deployments while provider integration is being tuned. They distinguish a model-quality problem from a contract/compiler/canvas problem quickly.

--- a/docs/handoffs/BRE-145-knowledge-packs.md
+++ b/docs/handoffs/BRE-145-knowledge-packs.md
@@ -1,0 +1,86 @@
+# BRE-145 Curated Agent Knowledge Packs Handoff
+
+Last updated: 2026-07-20
+
+## What this delivers
+
+Authored, structured knowledge packs for the four featured/projects of interest — **MALCOM**, **Dispatch**, **Orca Mail**, **FlowState** — plus a lazy-selection loader, JSON API for agent consumption, and a dev-only viewer for local testing. Packs are **data files**, so updating project knowledge does not require editing the canvas UI (acceptance criterion).
+
+## Where the implementation lives
+
+Branch: `luke/bre-145` (worktree at `../personal-website-bre-145`). Branched from `origin/main`. The packs are foundational content/data and are independent of the canvas compiler machinery on `homepage-canvas`; integrating them into the vision-agent request flow is a follow-up on the `homepage-canvas` branch (see "Integration" below).
+
+Key files:
+
+- `src/data/knowledge-packs/schema.ts` — `KnowledgePack` type and the slug registry.
+- `src/data/knowledge-packs/<slug>.ts` — one authored pack per project (`malcom`, `dispatch`, `orca-mail`, `flowstate`).
+- `src/data/knowledge-packs/index.ts` — registry + `listKnowledgePacks`, `getKnowledgePack`, and `buildAgentPromptContext(slug)` (renders the pack into a single markdown context string for a model).
+- `src/app/api/knowledge-packs/route.ts` — `GET /api/knowledge-packs` lists pack summaries.
+- `src/app/api/knowledge-packs/[slug]/route.ts` — `GET /api/knowledge-packs/<slug>` returns the full pack **and** the pre-rendered agent prompt context.
+- `src/components/knowledge-pack-viewer.tsx` + `src/app/knowledge-packs/page.tsx` — dev-only viewer at `/knowledge-packs` (redirects to `/projects` in production; visible in dev and Vercel preview).
+
+## Pack schema
+
+Each `KnowledgePack` includes exactly the sections the ticket requires:
+
+- `summary` / `purpose` / `intendedUser`
+- `architecture` + `components[]`
+- `designDecisions[]` (decision + rationale)
+- `status` + honest `limitations[]`
+- `technologies[]` + `links[]`
+- `visualVocabulary[]` (tokens, colors, motifs) — shared with diagram generation
+- `diagramPatterns[]` (name, description, nodes, style) — starter diagrams and dynamic generation read the **same facts**
+- `relationships[]` to the other projects
+- `followUpQA[]` — answers to likely follow-up questions
+
+## Acceptance criteria mapping
+
+- **Accurate and consistent with portfolio pages** — authored directly from `src/data/projects.ts`, `src/app/projects/[slug]/page.tsx` highlights, and the dedicated `flowstate` page.
+- **Selectable without placing every project in every prompt** — agents fetch one slug via the API or import one pack; `buildAgentPromptContext(slug)` returns only that project's context.
+- **Starter diagrams and dynamic generation use the same facts** — `diagramPatterns` and the rest of the pack share one authored source; a model generates diagrams from the same `architecture`/`components` facts the starter patterns use.
+- **Updating project knowledge does not require editing the canvas UI** — edits go in `src/data/knowledge-packs/<slug>.ts` (or future Markdown sources); the canvas never needs to change.
+
+## Local testing
+
+```bash
+npm install
+npm run dev     # open http://localhost:3000/knowledge-packs
+```
+
+Verify:
+
+- The viewer lists all four packs; selecting each loads the full pack and the generated agent prompt.
+- The "Agent prompt" tab renders the same context a model would receive; "Copy" works.
+- `GET /api/knowledge-packs` and `GET /api/knowledge-packs/malcom` return JSON (test with `curl`).
+- `npx tsc --noEmit`, `npm run lint`, and `npm run build` all pass.
+
+## Integration (follow-up, on `homepage-canvas`)
+
+When wiring into the vision-agent request flow (BRE-144 and beyond), fetch the relevant pack for the active project context and prepend its `buildAgentPromptContext(slug)` to the model prompt. Keep the same sequence the canvas lab uses; do not bypass the `CanvasPatchV1` contract.
+
+```text
+active project slug
+  -> GET /api/knowledge-packs/<slug>   (or server-side import)
+  -> prepend prompt context to the Gemini request
+  -> CanvasPatchV1 -> validate -> compile -> confirm -> apply
+```
+
+## Optional: ingesting Malcolm chat history over Tailscale (NOT done in this PR)
+
+The ticket discussion suggested indexing chat logs from Malcolm over Tailscale, scrubbing sensitive data, vectorizing, and offering the synthesis to the model. This was **not executed** from this environment — opencode has no network path to Malcolm and no Tailscale access here. Instead, an opt-in ingestion + scrubbing script is provided so it can be run from a machine that can reach Malcolm:
+
+- `scripts/ingest-malcom-chats.ts` — reads exported chat log files from a local directory, scrubs obvious secrets (API keys, bearer tokens, emails, phone numbers, credit-card-shaped strings), and writes a scrubbed JSONL chunk index plus a simple keyword index. It does **not** embed by default (no embeddings dependency added); it documents where to plug in an embeddings provider. Always review scrubbed output before using it as agent context.
+
+Run it from a host that can reach Malcolm (e.g. the Mac Malcolm runs on, or a machine on the same Tailnet):
+
+```bash
+tsx scripts/ingest-malcom-chats.ts --input <exported-chats-dir> --output .private/malcom-index.jsonl
+```
+
+Review `.private/malcom-index.jsonl` for residual sensitive content before exposing it to any model. `.private/` is already outside the public web root.
+
+## Gotchas
+
+- The viewer is gated to non-production (`NODE_ENV !== "production"` or `VERCEL_ENV === "preview"`), mirroring the BRE-143 canvas lab convention. A local `next build && next start` hides it; use `npm run dev`.
+- `force-static` on the API routes means packs are baked at build time — fine for authored content; update by editing the data file and redeploying.
+- Builds can modify `next-env.d.ts` / `tsconfig.tsbuildinfo`; stage source paths explicitly rather than `git add -A`.

--- a/scripts/ingest-malcom-chats.ts
+++ b/scripts/ingest-malcom-chats.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env tsx
+/**
+ * BRE-145 — Optional Malcolm chat ingestion + scrubbing.
+ *
+ * Run this FROM A HOST THAT CAN REACH MALCOM (the Mac Malcolm runs on, or a
+ * machine on the same Tailnet). opencode cannot reach Malcolm from this
+ * environment, so this script is intentionally opt-in and offline: it reads
+ * exported chat log files from a local directory, scrubs obvious secrets,
+ * and writes a scrubbed chunk index. It does NOT embed by default — no
+ * embeddings dependency is added. See the handoff doc for wiring guidance.
+ *
+ * ALWAYS review the scrubbed output before exposing it to a model.
+ *
+ * Usage:
+ *   tsx scripts/ingest-malcom-chats.ts --input <exported-chats-dir> --output .private/malcom-index.jsonl
+ *
+ * Export your chat logs (from Malcolm's session registry / logs) as plain text
+ * or markdown files into a directory, then point --input at that directory.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+
+interface Args {
+  input: string;
+  output: string;
+  chunkSize: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { input: "", output: "", chunkSize: 1200 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--input") args.input = argv[++i];
+    else if (a === "--output") args.output = argv[++i];
+    else if (a === "--chunk-size") args.chunkSize = Number(argv[++i]) || 1200;
+    else if (a === "-h" || a === "--help") {
+      console.log("Usage: tsx scripts/ingest-malcom-chats.ts --input <dir> --output <file.jsonl> [--chunk-size N]");
+      process.exit(0);
+    }
+  }
+  if (!args.input || !args.output) {
+    console.error("Error: --input and --output are required");
+    process.exit(1);
+  }
+  return args;
+}
+
+const SCRUB_PATTERNS: { name: string; re: RegExp; replacement: string }[] = [
+  { name: "bearer/token", re: /\b(sk-[A-Za-z0-9_-]{20,}|Bearer\s+[A-Za-z0-9._-]{16,}|[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{24,})\b/g, replacement: "[REDACTED_TOKEN]" },
+  { name: "api-key", re: /\b(api[_-]?key["'\s:=]+["']?[A-Za-z0-9_-]{16,})\b/gi, replacement: "[REDACTED_API_KEY]" },
+  { name: "password", re: /\b(password|passwd|pwd)["'\s:=]+["']?[^\s"']{4,}/gi, replacement: "[REDACTED_PASSWORD]" },
+  { name: "email", re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, replacement: "[REDACTED_EMAIL]" },
+  { name: "phone", re: /\b(\+?\d{1,2}[\s.-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/g, replacement: "[REDACTED_PHONE]" },
+  { name: "credit-card", re: /\b(?:\d[ -]*?){13,16}\b/g, replacement: "[REDACTED_CC]" },
+  { name: "private-key-block", re: /-----BEGIN (?:RSA |EC |OPENSSH |)PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |OPENSSH |)PRIVATE KEY-----/g, replacement: "[REDACTED_PRIVATE_KEY]" },
+  { name: "aws", re: /\b(AKIA[0-9A-Z]{16}|aws_secret_access_key["'\s:=]+["']?[A-Za-z0-9/+=]{40})\b/g, replacement: "[REDACTED_AWS]" },
+];
+
+interface ScrubResult {
+  text: string;
+  counts: Record<string, number>;
+}
+
+function scrub(text: string): ScrubResult {
+  const counts: Record<string, number> = {};
+  let out = text;
+  for (const p of SCRUB_PATTERNS) {
+    const before = out;
+    out = out.replace(p.re, p.replacement);
+    const matches = before.match(p.re);
+    if (matches) counts[p.name] = matches.length;
+  }
+  return { text: out, counts };
+}
+
+function chunk(text: string, size: number): string[] {
+  const paragraphs = text.split(/\n\s*\n/);
+  const chunks: string[] = [];
+  let current = "";
+  for (const para of paragraphs) {
+    if ((current + "\n\n" + para).length > size && current) {
+      chunks.push(current.trim());
+      current = para;
+    } else {
+      current = current ? `${current}\n\n${para}` : para;
+    }
+  }
+  if (current.trim()) chunks.push(current.trim());
+  return chunks;
+}
+
+const STOPWORDS = new Set([
+  "the","a","an","and","or","but","to","of","in","on","for","is","are","was","were","be","with","this","that","it","as","at","by","i","you","he","she","we","they","not","so","if","then","than","from","your","our","his","her","its",
+]);
+
+function keywords(text: string): string[] {
+  const freq = new Map<string, number>();
+  for (const raw of text.toLowerCase().match(/[a-z][a-z0-9_-]{2,}/g) ?? []) {
+    if (STOPWORDS.has(raw)) continue;
+    freq.set(raw, (freq.get(raw) ?? 0) + 1);
+  }
+  return [...freq.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12).map(([w]) => w);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const inputDir = resolve(args.input);
+  const outputPath = resolve(args.output);
+
+  let files: string[];
+  try {
+    files = readdirSync(inputDir).filter((f) => /\.(txt|md|log|json)$/i.test(f));
+  } catch {
+    console.error(`Error: cannot read input directory: ${inputDir}`);
+    process.exit(1);
+  }
+  if (files.length === 0) {
+    console.error(`Error: no .txt/.md/.log/.json files found in ${inputDir}`);
+    process.exit(1);
+  }
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+
+  const records: object[] = [];
+  let totalRedactions = 0;
+  let chunksWritten = 0;
+
+  for (const file of files) {
+    const path = join(inputDir, file);
+    const raw = readFileSync(path, "utf8");
+    const { text, counts } = scrub(raw);
+    const redactions = Object.values(counts).reduce((a, b) => a + b, 0);
+    totalRedactions += redactions;
+    for (const c of chunk(text, args.chunkSize)) {
+      records.push({
+        source: file,
+        keywords: keywords(c),
+        text: c,
+      });
+      chunksWritten++;
+    }
+    const flagged = Object.entries(counts).filter(([, n]) => n > 0);
+    console.log(`scrubbed ${file}: ${redactions} redaction(s)${flagged.length ? ` [${flagged.map(([k, v]) => `${k}:${v}`).join(", ")}]` : ""}`);
+  }
+
+  const jsonl = records.map((r) => JSON.stringify(r)).join("\n");
+  writeFileSync(outputPath, jsonl + "\n", "utf8");
+
+  console.log("");
+  console.log(`Files processed : ${files.length}`);
+  console.log(`Chunks written : ${chunksWritten}`);
+  console.log(`Total redactions: ${totalRedactions}`);
+  console.log(`Output          : ${outputPath}`);
+  console.log("");
+  console.log("REVIEW the output for residual sensitive content before exposing it to a model.");
+}
+
+main();

--- a/src/app/api/knowledge-packs/[slug]/route.ts
+++ b/src/app/api/knowledge-packs/[slug]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import {
+  buildAgentPromptContext,
+  getKnowledgePack,
+} from "@/data/knowledge-packs";
+
+export const dynamic = "force-static";
+
+export function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  return (async () => {
+    const { slug } = await params;
+    const pack = getKnowledgePack(slug);
+    if (!pack) {
+      return NextResponse.json(
+        { error: `Unknown knowledge pack: ${slug}` },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({
+      pack,
+      prompt: buildAgentPromptContext(slug),
+    });
+  })();
+}

--- a/src/app/api/knowledge-packs/route.ts
+++ b/src/app/api/knowledge-packs/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { listKnowledgePacks } from "@/data/knowledge-packs";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return NextResponse.json({ packs: listKnowledgePacks() });
+}

--- a/src/app/knowledge-packs/page.tsx
+++ b/src/app/knowledge-packs/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import { listKnowledgePacks } from "@/data/knowledge-packs";
+import KnowledgePackViewer from "@/components/knowledge-pack-viewer";
+
+export const dynamic = "force-static";
+
+export default function KnowledgePacksPage() {
+  const isProd =
+    process.env.NODE_ENV === "production" &&
+    process.env.VERCEL_ENV !== "preview";
+
+  if (isProd) {
+    redirect("/projects");
+  }
+
+  const summaries = listKnowledgePacks();
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-6xl px-6 py-16">
+        <header className="mb-10">
+          <p className="text-sm font-medium text-muted-foreground">
+            BRE-145 · Dev-only
+          </p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight">
+            Agent Knowledge Packs
+          </h1>
+          <p className="mt-3 max-w-2xl text-muted-foreground">
+            Curated, authored knowledge for the visual agent. Select a project
+            to inspect its pack, the generated agent prompt context, diagram
+            patterns, and likely follow-up answers. Packs are data files —
+            update them without touching the canvas UI.
+          </p>
+        </header>
+        <KnowledgePackViewer summaries={summaries} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/knowledge-pack-viewer.tsx
+++ b/src/components/knowledge-pack-viewer.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState } from "react";
+import type { KnowledgePackSummary } from "@/data/knowledge-packs";
+import { type KnowledgePack } from "@/data/knowledge-packs/schema";
+
+interface Props {
+  summaries: KnowledgePackSummary[];
+}
+
+type Tab = "pack" | "prompt";
+
+export default function KnowledgePackViewer({ summaries }: Props) {
+  const [activeSlug, setActiveSlug] = useState<string>(summaries[0]?.slug ?? "");
+  const [pack, setPack] = useState<KnowledgePack | null>(null);
+  const [prompt, setPrompt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("pack");
+  const [copied, setCopied] = useState(false);
+
+  async function loadPack(slug: string) {
+    setActiveSlug(slug);
+    setPack(null);
+    setPrompt(null);
+    setError(null);
+    setCopied(false);
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/knowledge-packs/${slug}`);
+      if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const data = (await res.json()) as { pack: KnowledgePack; prompt: string };
+      setPack(data.pack);
+      setPrompt(data.prompt);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load pack");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function copyPrompt() {
+    if (!prompt) return;
+    await navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[260px_1fr]">
+      <nav className="space-y-2">
+        {summaries.map((s) => {
+          const active = s.slug === activeSlug;
+          return (
+            <button
+              key={s.slug}
+              onClick={() => loadPack(s.slug)}
+              className={`w-full rounded-xl border p-4 text-left transition ${
+                active
+                  ? "border-foreground/20 bg-foreground/5"
+                  : "border-transparent hover:border-foreground/10 hover:bg-foreground/[0.03]"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                {s.emoji && <span>{s.emoji}</span>}
+                <span className="font-semibold">{s.title}</span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                {s.summary}
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: s.brandColor }}
+                />
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: s.accentColor }}
+                />
+                <span className="text-[11px] text-muted-foreground">
+                  {s.lastAuthored}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </nav>
+
+      <section className="min-h-[60vh] rounded-2xl border border-foreground/10 p-6">
+        {loading && <p className="text-muted-foreground">Loading pack…</p>}
+        {error && <p className="text-red-500">{error}</p>}
+        {!loading && !pack && !error && (
+          <p className="text-muted-foreground">Select a project to inspect its knowledge pack.</p>
+        )}
+        {pack && (
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-2xl font-bold">
+                  {pack.emoji ? `${pack.emoji} ` : ""}
+                  {pack.title}
+                </h2>
+                <p className="mt-1 max-w-2xl text-muted-foreground">{pack.summary}</p>
+              </div>
+              <div className="flex rounded-lg border border-foreground/10 p-1 text-sm">
+                <button
+                  onClick={() => setTab("pack")}
+                  className={`rounded-md px-3 py-1 ${tab === "pack" ? "bg-foreground/10 font-medium" : "text-muted-foreground"}`}
+                >
+                  Pack
+                </button>
+                <button
+                  onClick={() => setTab("prompt")}
+                  className={`rounded-md px-3 py-1 ${tab === "prompt" ? "bg-foreground/10 font-medium" : "text-muted-foreground"}`}
+                >
+                  Agent prompt
+                </button>
+              </div>
+            </div>
+
+            {tab === "prompt" ? (
+              <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-muted-foreground">
+                    Synthetic context delivered to the model for this project.
+                  </span>
+                  <button
+                    onClick={copyPrompt}
+                    className="rounded-md border border-foreground/15 px-3 py-1 text-xs hover:bg-foreground/5"
+                  >
+                    {copied ? "Copied!" : "Copy"}
+                  </button>
+                </div>
+                <pre className="overflow-auto rounded-xl bg-foreground/[0.03] p-4 text-xs leading-relaxed whitespace-pre-wrap">
+                  {prompt ?? ""}
+                </pre>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <Field label="Purpose">{pack.purpose}</Field>
+                <Field label="Intended user">{pack.intendedUser}</Field>
+                <Field label="Architecture">{pack.architecture}</Field>
+
+                <Field label="Components">
+                  <ul className="space-y-1">
+                    {pack.components.map((c) => (
+                      <li key={c.name} className="text-sm">
+                        <span className="font-medium">{c.name}</span>
+                        <span className="text-muted-foreground"> — {c.role}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Field>
+
+                <Field label="Design decisions">
+                  <ul className="space-y-1">
+                    {pack.designDecisions.map((d) => (
+                      <li key={d.decision} className="text-sm">
+                        <span className="font-medium">{d.decision}</span>
+                        <span className="text-muted-foreground"> — {d.rationale}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Field>
+
+                <Field label="Status">{pack.status}</Field>
+
+                <Field label="Honest limitations">
+                  <ul className="list-disc space-y-1 pl-5 text-sm">
+                    {pack.limitations.map((l) => (
+                      <li key={l}>{l}</li>
+                    ))}
+                  </ul>
+                </Field>
+
+                <Field label="Technologies">
+                  <div className="flex flex-wrap gap-2">
+                    {pack.technologies.map((t) => (
+                      <span
+                        key={t}
+                        className="rounded-full border border-foreground/10 px-3 py-1 text-xs"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                </Field>
+
+                {pack.links.length > 0 && (
+                  <Field label="Links">
+                    <ul className="space-y-1 text-sm">
+                      {pack.links.map((l) => (
+                        <li key={l.url}>
+                          <a
+                            href={l.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="underline underline-offset-2"
+                          >
+                            {l.label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </Field>
+                )}
+
+                <Field label="Visual vocabulary">
+                  <ul className="space-y-1 text-sm">
+                    {pack.visualVocabulary.map((v) => (
+                      <li key={v.token} className="flex items-center gap-2">
+                        {v.value && (
+                          <span
+                            className="h-3 w-3 rounded-full border border-foreground/10"
+                            style={{ backgroundColor: v.value }}
+                          />
+                        )}
+                        <span className="font-medium">{v.token}</span>
+                        <span className="text-muted-foreground">— {v.usage}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Field>
+
+                <Field label="Suggested diagram patterns">
+                  <div className="space-y-3">
+                    {pack.diagramPatterns.map((d) => (
+                      <div
+                        key={d.name}
+                        className="rounded-xl border border-foreground/10 p-4"
+                      >
+                        <p className="font-medium">{d.name}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {d.description}
+                        </p>
+                        <p className="mt-2 text-xs">
+                          <span className="font-medium">Nodes:</span>{" "}
+                          {d.nodes.join(", ")}
+                        </p>
+                        <p className="mt-1 text-xs">
+                          <span className="font-medium">Style:</span> {d.style}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </Field>
+
+                <Field label="Relationships">
+                  <ul className="space-y-1 text-sm">
+                    {pack.relationships.map((r) => (
+                      <li key={r.toProject}>
+                        <span className="font-medium">{r.toProject}</span>
+                        <span className="text-muted-foreground"> — {r.relation}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Field>
+
+                <Field label="Likely follow-up questions">
+                  <div className="space-y-3">
+                    {pack.followUpQA.map((q) => (
+                      <div
+                        key={q.question}
+                        className="rounded-xl border border-foreground/10 p-4"
+                      >
+                        <p className="font-medium">Q: {q.question}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          A: {q.answer}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </Field>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <div className="text-sm leading-relaxed">{children}</div>
+    </div>
+  );
+}

--- a/src/data/knowledge-packs/canvas-notion.ts
+++ b/src/data/knowledge-packs/canvas-notion.ts
@@ -1,0 +1,74 @@
+import type { KnowledgePack } from "./schema";
+
+export const canvasNotionPack: KnowledgePack = {
+  slug: "canvas-notion",
+  title: "Canvas-Notion Automation",
+  summary:
+    "An academic workflow bridge that pulls Canvas assignments into Notion so deadlines, priorities, grades, and submission status live in one organized planning system.",
+  purpose:
+    "Eliminate manual перекopying by syncing assignments from a Canvas LMS into Notion, giving students one place to track deadlines, priorities, grades, and submission status instead of juggling the LMS UI alongside their planning system.",
+  intendedUser:
+    "Students using Canvas who keep their planning system in Notion and want academic deadlines and status to flow in automatically rather than by hand.",
+  architecture:
+    "A Python service authenticates against the Canvas API on a schedule and pulls assignments, due dates, grades, and submission status. A mapping layer translates Canvas entities into Notion database rows, preserving priorities and status. Notion's API is the write target; Canvas is read-only source. The bridge is a scheduled sync rather than a live event stream.",
+  components: [
+    { name: "Canvas API connector", role: "Reads assignments, due dates, grades, and submission status from the Canvas LMS API." },
+    { name: "Entity mapper", role: "Translates Canvas items into Notion database rows, preserving priority and status semantics." },
+    { name: "Notion API writer", role: "Inserts/updates rows in a Notion database that serves as the planning hub." },
+    { name: "Scheduler", role: "Runs the sync on a recurring cadence rather than reacting to live events." },
+    { name: "Status normalization", role: "Keeps submission status and grades consistent between Canvas and Notion." },
+  ],
+  designDecisions: [
+    { decision: "Canvas read-only, Notion write target", rationale: "Canvas is the source of truth for assignments; Notion is the planning surface. One-way sync avoids reconciliation conflicts." },
+    { decision: "Scheduled sync over live events", rationale: "Canvas webhook/event plumbing adds reliability burden; a schedule is sufficient for academic timescales." },
+    { decision: "Preserve priority + status semantics across systems", rationale: "Deadlines and submission status need to mean the same thing on both sides so prioritization is trustworthy." },
+    { decision: "Automate the mapping, not the planning", rationale: "Data flows in; the student still makes prioritization and planning decisions." },
+  ],
+  status: "Completed (July 2025). A finished, working academic-workflow artifact.",
+  limitations: [
+    "Canvas-specific; the bridge is not generalized to other LMSes.",
+    "Scheduled sync means near-real-time Canvas changes appear on the next run, not instantly.",
+    "Single Notion database schema assumed; custom Notion layouts may need mapping tweaks.",
+    "Academic-focused — not a general task/assignment sync tool.",
+  ],
+  technologies: ["Python", "Canvas API", "Notion API", "Data Modeling", "Automation"],
+  links: [{ label: "Source", url: "https://github.com/lukebrevoort/CanvasToNotion" }],
+  visualVocabulary: [
+    { token: "Primary red", usage: "Deadlines, urgent items", value: "#dc2626" },
+    { token: "Black accent", usage: "Status, structural elements", value: "#000000" },
+    { token: "One-way flow motif", usage: "Depict Canvas → Notion as a one-directional sync, not bidirectional" },
+    { token: "Database/grid glyph", usage: "Represent Notion database rows being updated" },
+  ],
+  diagramPatterns: [
+    {
+      name: "One-way Canvas → Notion sync",
+      description: "Canvas (source) flows through the mapper into the Notion planning database (target).",
+      nodes: ["Canvas LMS", "Canvas API connector", "Entity mapper", "Notion API writer", "Notion planning database"],
+      style: "Left-to-right pipeline; a scheduler node feeding the connector. Red for the Canvas source edge, black for the Notion target. No return arrow.",
+    },
+    {
+      name: "Assignment-to-row mapping",
+      description: "A Canvas assignment maps to a Notion row with priority, due date, grade, and submission status fields.",
+      nodes: ["Canvas assignment", "Mapper", "Notion row", "Priority", "Due date", "Grade", "Submission status"],
+      style: "A single Canvas item expanding into the Notion row's fields on the right.",
+    },
+    {
+      name: "Scheduled sync cycle",
+      description: "A scheduler triggers the sync on a recurring cadence instead of subscribing to live events.",
+      nodes: ["Scheduler", "Canvas sync run", "Notion updates"],
+      style: "A loop/cycle icon on the scheduler feeding periodic sync runs.",
+    },
+  ],
+  relationships: [
+    { toProject: "FlowState", relation: "Thematic predecessor: both connect academic/LMS data to a planning surface; Canvas-Notion automates the data flow, FlowState later orchestrated study context more broadly." },
+  ],
+  followUpQA: [
+    { question: "Does it push changes from Notion back to Canvas?", answer: "No — sync is one-way. Canvas is the source of truth for assignments; Notion is where they are planned against." },
+    { question: "How current is the data in Notion?", answer: "Updates appear on the next scheduled sync run, not instantly. That is sufficient for academic timescales." },
+    { question: "Does it support LMSes other than Canvas?", answer: "No — it is Canvas-specific; generalizing the connector would replace the Canvas API client." },
+    { question: "Can I see the code?", answer: "Yes — the source is on GitHub at github.com/lukebrevoort/CanvasToNotion." },
+  ],
+  brandColor: "#dc2626",
+  accentColor: "#000000",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/dispatch.ts
+++ b/src/data/knowledge-packs/dispatch.ts
@@ -1,0 +1,84 @@
+import type { KnowledgePack } from "./schema";
+
+export const dispatchPack: KnowledgePack = {
+  slug: "dispatch",
+  title: "Dispatch",
+  summary:
+    "A local-first control plane for running and managing multiple AI coding agents from one workspace — tmux-backed persistence paired with browser terminals and worktree isolation.",
+  purpose:
+    "Keep many long-lived coding agents alive and observable from a single workspace, so work is not lost when a browser disconnects and parallel agent sessions can be run, inspected, and controlled side by side.",
+  intendedUser:
+    "Developers running several AI coding agents (Claude, Codex, Cursor, OpenCode, or a plain terminal) in parallel who want persistent, observable, isolated sessions without losing work on disconnect.",
+  architecture:
+    "Agents run in tmux-backed sessions for persistence; interactive xterm.js browser terminals pair with those sessions so a disconnect does not kill the work. Each agent gets Git worktree isolation. A PostgreSQL store backed by a Bun runtime holds lifecycle, jobs, media, and analytics. Project-scoped MCP tools, pins, notifications, and a collaborative whiteboard surface sit alongside the terminal/agent layer.",
+  components: [
+    { name: "Agent session manager", role: "Runs long-lived agents in tmux-backed sessions that survive browser disconnects." },
+    { name: "Browser terminal bridge", role: "xterm.js terminals in the browser paired to tmux sessions." },
+    { name: "Worktree isolation", role: "Per-agent Git worktrees so parallel sessions do not collide on the same checkout." },
+    { name: "Lifecycle controls + jobs", role: "Start/stop/restart agents and schedule recurring jobs." },
+    { name: "Review personas", role: "Reusable agent personas/roles for review and other repeated workflows." },
+    { name: "Context surfacing", role: "Live status events, media sharing, browser streaming, pins, notifications, and activity analytics." },
+    { name: "Project-scoped MCP tools", role: "Scoped MCP tool registry per project." },
+    { name: "Collaborative whiteboard", role: "A shared canvas surface; the part Luke contributed to and helped shape." },
+  ],
+  designDecisions: [
+    { decision: "tmux-backed session persistence", rationale: "Browser disconnects should not kill long-running agents; tmux keeps the session alive independently of the client." },
+    { decision: "xterm.js + tmux pairing", rationale: "Interactive browser terminals that reconnect to durable tmux sessions give both responsiveness and persistence." },
+    { decision: "Git worktree isolation per agent", rationale: "Parallel agents working in the same repo need isolated checkouts to avoid file collisions." },
+    { decision: "Provider-agnostic agent support", rationale: "Claude, Codex, Cursor, OpenCode, or a plain terminal run through one control plane." },
+    { decision: "Local-first", rationale: "Keeps the control plane under the operator's machine rather than a hosted SaaS." },
+  ],
+  status: "In progress (2026 – Present). Collaborative project; Luke's contribution focuses on the whiteboard surface plus product development, debugging, and interaction design.",
+  limitations: [
+    "Source belongs to a collaborative repo (github.com/selfcontained/dispatch); Luke contributed the whiteboard surface and product/interaction work, not the entire codebase.",
+    "No public demo URL is linked.",
+    "Active development — feature coverage evolves.",
+  ],
+  technologies: ["TypeScript", "Bun", "PostgreSQL", "tmux", "MCP", "Product Design"],
+  links: [{ label: "Source (collaborative repo)", url: "https://github.com/selfcontained/dispatch" }],
+  visualVocabulary: [
+    { token: "Primary purple", usage: "Agent/control surfaces", value: "#7c3aed" },
+    { token: "Pink accent", usage: "Whiteboard, media, highlights", value: "#db2777" },
+    { token: "Multi-lane/multi-agent motif", usage: "Depict parallel agent sessions side by side" },
+    { token: "Terminal glyphs", usage: "xterm.js pairing with tmux persistence" },
+  ],
+  diagramPatterns: [
+    {
+      name: "Session persistence pairing",
+      description: "Browser xterm.js terminal on top, tmux session beneath, so a disconnect breaks only the top edge, not the session.",
+      nodes: ["xterm.js browser terminal", "tmux session", "Agent process"],
+      style: "Two-layer stack; a break symbol on the browser↔tmux edge to show disconnect-tolerance; use purple for control, pink for the live/interactive edge.",
+    },
+    {
+      name: "Multi-agent worktree lanes",
+      description: "Parallel agent lanes, each branching from the repo into its own worktree.",
+      nodes: ["Repo", "Agent A + worktree", "Agent B + worktree", "Agent C + worktree"],
+      style: "One repo node fanning into parallel lanes; each lane links an agent to its isolated worktree branch.",
+    },
+    {
+      name: "Context surface fan-out",
+      description: "From each agent session, fan out to the context surfaces: status events, media, browser streaming, pins, notifications, analytics.",
+      nodes: ["Agent session", "Status events", "Media sharing", "Browser streaming", "Pins", "Notifications", "Analytics"],
+      style: "Agent session on the left with rightward fan-out to surface nodes.",
+    },
+    {
+      name: "MCP tool registry",
+      description: "Project-scoped MCP tools attach to a project, available to its agents.",
+      nodes: ["Project", "MCP tool registry", "Agent sessions"],
+      style: "Project node holding a scoped tool registry that agents under that project can reach.",
+    },
+  ],
+  relationships: [
+    { toProject: "MALCOM", relation: "Shared agent-orchestration theme with different scope: Dispatch is a local-first collaborative multi-agent workspace; MALCOM is a single-operator remote Mac controller." },
+    { toProject: "FlowState", relation: "Thematic continuity in local-first control and context surfacing; Dispatch generalizes agent management where FlowState focused on study workflows." },
+  ],
+  followUpQA: [
+    { question: "What part did Luke build?", answer: "Luke contributed and helped shape the collaborative whiteboard surface, plus product development, debugging, and interaction work. The broader codebase is a collaborative project." },
+    { question: "What happens if I close the browser?", answer: "Agents keep running in tmux-backed sessions; reconnecting the xterm.js terminal restores the live session." },
+    { question: "Which agents are supported?", answer: "Claude, Codex, Cursor, OpenCode, or a plain terminal — all through one workspace with worktree isolation." },
+    { question: "Is there a hosted version?", answer: "Dispatch is local-first; no hosted/public demo URL is linked." },
+  ],
+  brandColor: "#7c3aed",
+  accentColor: "#db2777",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/flowstate.ts
+++ b/src/data/knowledge-packs/flowstate.ts
@@ -1,0 +1,82 @@
+import type { KnowledgePack } from "./schema";
+
+export const flowstatePack: KnowledgePack = {
+  slug: "flowstate",
+  title: "FlowState",
+  summary:
+    "A completed, early MCP-driven study-workflow experiment — a local-first OpenCode wrapper that brought academic context, connected apps, specialized agents, and approval-gated actions into one place.",
+  purpose:
+    "Give study workflows a durable, local-first context layer before modern MCP-based tooling made connected context a default expectation. FlowState wrapped OpenCode with specialized agents and app integrations to coordinate study and daily-work tools while keeping higher-risk actions behind explicit approval.",
+  intendedUser:
+    "Students who wanted a calm, local-first hub for assignments, course context, scheduling, and an AI study assistant — with human override controls so the system never locked them out of their own plan.",
+  architecture:
+    "FlowState wrapped OpenCode as its core, surrounded by specialized agents for distinct student needs and app integrations to Notion, Gmail, Google Calendar, and LMS APIs. Higher-risk actions required approval. Storage was local-first SQLite. The frontend emphasized calm typography, restrained color, and quiet motion for long sessions, with streaming responses and clear progress states.",
+  components: [
+    { name: "Real-time assistant", role: "Streaming responses with clear progress feedback." },
+    { name: "Unified academic hub", role: "Assignments, course context, and priorities in one place." },
+    { name: "Adaptive scheduling", role: "Adjusts to workload and focus patterns." },
+    { name: "Dynamic content", role: "Small interactive UI snippets instead of walls of text, when helpful." },
+    { name: "Lightweight analytics", role: "Overload warnings and productivity patterns without nagging." },
+    { name: "Human override controls", role: "Lock deadlines and reprioritize without fighting the system." },
+    { name: "Outcome-focused planning", role: "Turns raw requirements into a short, scannable daily plan." },
+  ],
+  designDecisions: [
+    { decision: "Local-first context layer", rationale: "Keep study context durable and private on the user's machine." },
+    { decision: "Approval-gated higher-risk actions", rationale: "Connected apps could act, but risky actions required explicit human approval." },
+    { decision: "Specialized agents per student need", rationale: "Distinct agents handled distinct tasks rather than one monolithic assistant." },
+    { decision: "Quiet, restrained UX", rationale: "Long study sessions needed calm typography, restrained color, and quiet motion." },
+    { decision: "Mobile-first layouts", rationale: "Quick replans between classes needed to work on a phone." },
+  ],
+  status: "Completed (2025 – 2026). A finished artifact from an earlier moment in agent tooling, now superseded by modern connected-context defaults.",
+  limitations: [
+    "Completed, not actively developed — it is a reference artifact, not a maintained product.",
+    "Pre-modern-MCP assumptions; the connected-context problem it solved is now partly a default expectation of newer tooling.",
+    "Scope was study workflows specifically, not general productivity.",
+  ],
+  technologies: ["TypeScript", "OpenCode", "MCP", "SQLite", "Notion", "Gmail", "Google Calendar"],
+  links: [
+    { label: "Source", url: "https://github.com/lukebrevoort/flowstate" },
+    { label: "Demo", url: "https://flowstate-self.vercel.app" },
+  ],
+  visualVocabulary: [
+    { token: "Primary orange", usage: "Brand, focus surfaces", value: "#d06224" },
+    { token: "Green accent", usage: "Success/planning, secondary surfaces", value: "#9eab57" },
+    { token: "Quiet/calm motif", usage: "Restrained color, calm typography, quiet motion for long sessions" },
+    { token: "Hub-and-spoke", usage: "OpenCode core connecting to app integrations" },
+    { token: "Approval gate glyph", usage: "Depict gated, human-approved higher-risk actions" },
+  ],
+  diagramPatterns: [
+    {
+      name: "OpenCode core hub-and-spoke",
+      description: "OpenCode core at the center connecting to specialized agents and app integrations.",
+      nodes: ["OpenCode core", "Specialized agents", "Notion", "Gmail", "Google Calendar", "LMS APIs"],
+      style: "Hub-and-spoke; OpenCode core at center, agents and integrations on spokes. Orange for core, green for integrations.",
+    },
+    {
+      name: "Approval gate",
+      description: "Higher-risk actions flow through an approval gate before executing against connected apps.",
+      nodes: ["Agent action", "Approval gate (human)", "Connected app"],
+      style: "A gate node between the agent and the app; only approved actions proceed; denied actions stop at the gate.",
+    },
+    {
+      name: "Daily plan flow",
+      description: "Raw requirements turn into a short, scannable daily plan with overrides.",
+      nodes: ["Raw requirements", "Outcome-focused planning", "Daily plan", "Human override"],
+      style: "Left-to-right pipeline with an override branch that can lock deadlines or reprioritize.",
+    },
+  ],
+  relationships: [
+    { toProject: "MALCOM", relation: "Conceptual predecessor: FlowState explored agent context, autonomy, and approval-gating; MALCOM applies similar control/inspection thinking to a durable execution layer." },
+    { toProject: "Orca Mail", relation: "Shared theme of reducing noise and protecting focus via connected-app integrations (Gmail/Calendar); FlowState planned across tools, Orca owns email." },
+    { toProject: "Dispatch", relation: "Thematic continuity in local-first control and context surfacing; Dispatch generalizes agent management where FlowState focused on study workflows." },
+  ],
+  followUpQA: [
+    { question: "Is FlowState still being worked on?", answer: "No — it is completed. It is a reference artifact from an earlier moment in agent tooling, not a maintained product." },
+    { question: "Why build it before MCP was common?", answer: "It predates today's connected-context defaults; it was an attempt to give study workflows a durable, local-first context layer before that became expected." },
+    { question: "Could risky actions happen automatically?", answer: "No — higher-risk actions were approval-gated and required explicit human approval before executing." },
+    { question: "Where can I see it?", answer: "Source is on GitHub (github.com/lukebrevoort/flowstate) and there is a demo at flowstate-self.vercel.app." },
+  ],
+  brandColor: "#d06224",
+  accentColor: "#9eab57",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/hftc.ts
+++ b/src/data/knowledge-packs/hftc.ts
@@ -1,0 +1,72 @@
+import type { KnowledgePack } from "./schema";
+
+export const hftcPack: KnowledgePack = {
+  slug: "hftc",
+  title: "HFTC",
+  summary:
+    "A competition trading system for the Stevens High-Frequency Trading Competition, combining market-making discipline with momentum-based strategies on the SHIFT platform.",
+  purpose:
+    "Build a trading system that competes in the Stevens HFTC on the SHIFT platform by combining market-making discipline (continuous two-sided quotes) with momentum-based directional strategies, balancing stability and edge within a competition market.",
+  intendedUser:
+    "The competition entry team / evaluators at the Stevens High-Frequency Trading Competition, and as a portfolio artifact showing algorithmic-trading systems thinking.",
+  architecture:
+    "A Python trading bot built on Backtrader runs strategies against the SHIFT competition platform. Two complementary strategy families share a common risk and execution shell: a market-making strategy maintaining two-sided quotes with spread discipline, and a momentum strategy that takes directional positions on detected price moves. The shell handles order routing, position tracking, and risk limits so each strategy focuses on signal and sizing.",
+  components: [
+    { name: "Execution/risk shell", role: "Common layer handling order routing to SHIFT, position tracking, and risk limits shared by both strategies." },
+    { name: "Market-making strategy", role: "Maintains two-sided quotes with spread discipline to capture the bid-ask spread while managing inventory." },
+    { name: "Momentum strategy", role: "Takes directional positions when detected price moves meet momentum criteria." },
+    { name: "Backtrader core", role: "Python framework backing the strategy definitions, backtests, and live execution." },
+    { name: "SHIFT platform adapter", role: "Routes orders and market data to/from the competition exchange." },
+  ],
+  designDecisions: [
+    { decision: "Pair market-making with momentum", rationale: "Market-making provides stability and persistent edge from the spread; momentum adds directional upside. Together they balance a competition portfolio rather than betting on one regime." },
+    { decision: "Shared risk shell for both strategies", rationale: "Position limits and order discipline apply to both strategies; centralizing them avoids inconsistent risk behavior." },
+    { decision: "Spread discipline over aggressive quoting", rationale: "In a competition market, avoiding adverse selection matters more than winning every fill; tight but disciplined quotes limit downside." },
+    { decision: "Backtrader for strategies and backtest", rationale: "One framework across research/backtest and live execution keeps behavior consistent between simulation and the competition." },
+  ],
+  status: "Completed (June 2025). A finished competition entry.",
+  limitations: [
+    "Competition-specific: targeted at the SHIFT platform, not a production broker API.",
+    "Competition market dynamics differ from real markets; results are not directly transferable to live trading.",
+    "Backtest fidelity is bounded by Backtrader simulation; assumptions about fills and slippage simplify real microstructure.",
+    "Not actively traded — it is a competition artifact, not a maintained strategy library.",
+  ],
+  technologies: ["Python", "Algorithm Development", "Backtrader", "Market Making", "Momentum Arbitrage"],
+  links: [],
+  visualVocabulary: [
+    { token: "Primary green", usage: "Gains, momentum, upward moves", value: "#10b981" },
+    { token: "Blue accent", usage: "Market-making, spreads, structure", value: "#3b82f6" },
+    { token: "Dual-lane motif", usage: "Depict market-making and momentum as two parallel strategy lanes feeding one risk shell" },
+    { token: "Bid-ask spread glyph", usage: "Represent the spread discipline of the market-maker" },
+  ],
+  diagramPatterns: [
+    {
+      name: "Dual-strategy lane",
+      description: "Market-making and momentum run as two parallel strategy lanes that both feed the shared execution/risk shell.",
+      nodes: ["Market-making strategy", "Momentum strategy", "Shared execution/risk shell", "SHIFT platform"],
+      style: "Two lanes converging into a shared shell that routes to SHIFT. Green for momentum, blue for market-making.",
+    },
+    {
+      name: "Two-sided quote spread",
+      description: "Market-maker maintains bid and ask around a fair value with a disciplined spread.",
+      nodes: ["Fair value", "Bid", "Ask", "Spread"],
+      style: "Fair value at center, bid below and ask above, spread labeled between them.",
+    },
+    {
+      name: "Momentum signal to position",
+      description: "A detected momentum signal triggers a directional position subject to risk limits.",
+      nodes: ["Price feed", "Momentum signal", "Position sizing", "Risk limit", "Directional order"],
+      style: "Pipeline from price feed → signal → sizing (bounded by risk limit) → order.",
+    },
+  ],
+  relationships: [],
+  followUpQA: [
+    { question: "Did it win the competition?", answer: "The system combined market-making with momentum in a balanced competition portfolio; the specific standing is a competition result. It is best read as a portfolio artifact showing coordinated strategy design." },
+    { question: "Is this used for real trading?", answer: "No — it targeted the SHIFT competition platform, not a production broker. Competition dynamics differ from live markets." },
+    { question: "Why pair the two strategies?", answer: "Market-making adds stability and edge from the spread; momentum adds directional upside. Together they avoid betting the whole entry on one market regime." },
+    { question: "What framework is it built on?", answer: "Python with Backtrader, used for both backtests and live execution so behavior stays consistent." },
+  ],
+  brandColor: "#10b981",
+  accentColor: "#3b82f6",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/index.ts
+++ b/src/data/knowledge-packs/index.ts
@@ -1,0 +1,103 @@
+import { knowledgePackSlugs, type KnowledgePack, type KnowledgePackSlug } from "./schema";
+import { malcomPack } from "./malcom";
+import { dispatchPack } from "./dispatch";
+import { orcaMailPack } from "./orca-mail";
+import { flowstatePack } from "./flowstate";
+
+export type { KnowledgePack, KnowledgePackSlug } from "./schema";
+
+const packs: Record<KnowledgePackSlug, KnowledgePack> = {
+  malcom: malcomPack,
+  dispatch: dispatchPack,
+  "orca-mail": orcaMailPack,
+  flowstate: flowstatePack,
+};
+
+export function listKnowledgePackSlugs(): readonly KnowledgePackSlug[] {
+  return knowledgePackSlugs;
+}
+
+export interface KnowledgePackSummary {
+  slug: string;
+  title: string;
+  summary: string;
+  status: string;
+  brandColor: string;
+  accentColor: string;
+  emoji?: string;
+  lastAuthored: string;
+}
+
+export function listKnowledgePacks(): KnowledgePackSummary[] {
+  return knowledgePackSlugs.map((slug) => {
+    const pack = packs[slug];
+    return {
+      slug: pack.slug,
+      title: pack.title,
+      summary: pack.summary,
+      status: pack.status,
+      brandColor: pack.brandColor,
+      accentColor: pack.accentColor,
+      emoji: pack.emoji,
+      lastAuthored: pack.lastAuthored,
+    };
+  });
+}
+
+export function getKnowledgePack(slug: string): KnowledgePack | undefined {
+  return packs[slug as KnowledgePackSlug];
+}
+
+export function buildAgentPromptContext(slug: string): string | undefined {
+  const pack = getKnowledgePack(slug);
+  if (!pack) return undefined;
+
+  const lines: string[] = [];
+  lines.push(`# ${pack.title}`);
+  lines.push(pack.summary);
+  lines.push("");
+  lines.push(`## Purpose`);
+  lines.push(pack.purpose);
+  lines.push(`Intended user: ${pack.intendedUser}`);
+  lines.push("");
+  lines.push(`## Architecture`);
+  lines.push(pack.architecture);
+  lines.push("");
+  lines.push(`## Components`);
+  for (const c of pack.components) lines.push(`- ${c.name}: ${c.role}`);
+  lines.push("");
+  lines.push(`## Design decisions`);
+  for (const d of pack.designDecisions)
+    lines.push(`- ${d.decision} — ${d.rationale}`);
+  lines.push("");
+  lines.push(`## Status`);
+  lines.push(pack.status);
+  lines.push("");
+  lines.push(`## Honest limitations`);
+  for (const l of pack.limitations) lines.push(`- ${l}`);
+  lines.push("");
+  lines.push(`## Technologies`);
+  lines.push(pack.technologies.join(", "));
+  if (pack.links.length) {
+    lines.push("");
+    lines.push(`## Links`);
+    for (const link of pack.links) lines.push(`- ${link.label}: ${link.url}`);
+  }
+  lines.push("");
+  lines.push(`## Visual vocabulary`);
+  for (const v of pack.visualVocabulary)
+    lines.push(`- ${v.token} (${v.usage})${v.value ? ` [${v.value}]` : ""}`);
+  lines.push("");
+  lines.push(`## Suggested diagram patterns`);
+  for (const d of pack.diagramPatterns)
+    lines.push(`- ${d.name}: ${d.description} — nodes: ${d.nodes.join(", ")}. Style: ${d.style}`);
+  lines.push("");
+  lines.push(`## Relationships to other projects`);
+  for (const r of pack.relationships) lines.push(`- ${r.toProject}: ${r.relation}`);
+  lines.push("");
+  lines.push(`## Likely follow-up questions`);
+  for (const q of pack.followUpQA)
+    lines.push(`- Q: ${q.question}\n  A: ${q.answer}`);
+
+  return lines.join("\n");
+}

--- a/src/data/knowledge-packs/index.ts
+++ b/src/data/knowledge-packs/index.ts
@@ -3,6 +3,12 @@ import { malcomPack } from "./malcom";
 import { dispatchPack } from "./dispatch";
 import { orcaMailPack } from "./orca-mail";
 import { flowstatePack } from "./flowstate";
+import { canvasNotionPack } from "./canvas-notion";
+import { hftcPack } from "./hftc";
+import { zen80Pack } from "./zen80";
+import { whileUnemployedPack } from "./while-unemployed";
+import { sgaFinancePack } from "./sga-finance";
+import { personalWebsitePack } from "./personal-website";
 
 export type { KnowledgePack, KnowledgePackSlug } from "./schema";
 
@@ -11,6 +17,12 @@ const packs: Record<KnowledgePackSlug, KnowledgePack> = {
   dispatch: dispatchPack,
   "orca-mail": orcaMailPack,
   flowstate: flowstatePack,
+  "canvas-notion": canvasNotionPack,
+  hftc: hftcPack,
+  zen80: zen80Pack,
+  "while-unemployed": whileUnemployedPack,
+  "sga-finance": sgaFinancePack,
+  website: personalWebsitePack,
 };
 
 export function listKnowledgePackSlugs(): readonly KnowledgePackSlug[] {

--- a/src/data/knowledge-packs/malcom.ts
+++ b/src/data/knowledge-packs/malcom.ts
@@ -1,0 +1,77 @@
+import type { KnowledgePack } from "./schema";
+
+export const malcomPack: KnowledgePack = {
+  slug: "malcom",
+  title: "MALCOM",
+  summary:
+    "Controller layer for a remote, Mac-based personal coding and assistant host — the stable execution plane behind Hermes, the conversational orchestrator.",
+  purpose:
+    "Give long-running agent work a stable home that survives disconnects: a controlled execution layer that owns the session registry, workspace layout, logs, and policy boundaries for a remote Mac that hosts coding and assistant harnesses. Hermes handles the conversation; MALCOM controls what actually runs and for how long.",
+  intendedUser:
+    "Luke, operating as a single operator orchestrating many parallel agent tasks from a remote Mac host. Not a multi-tenant product — a personal control plane.",
+  architecture:
+    "MALCOM sits between a conversational orchestrator (Hermes) and the remote Mac runtime. It exposes a stable CLI surface to start and track harnesses (manual shells, Codex, OpenCode, Cursor) and routes to external services through discrete adapters (GitHub, Notion, Linear). The session registry is the source of truth for what is running, where, and with what workspace. Policy and logging are first-class so any action is inspectable and recoverable after the fact.",
+  components: [
+    { name: "Session registry", role: "Source of truth for live and historical sessions; what is running, on which harness, and with what workspace." },
+    { name: "Workspace layout manager", role: "Owns per-session worktree/layout so long-running work has a stable, recoverable filesystem context." },
+    { name: "CLI command surface", role: "Stable commands to start and track manual, Codex, OpenCode, and Cursor harnesses without coupling the controller to any one provider." },
+    { name: "Adapter layer", role: "Connects GitHub, Notion, and Linear behind a constrained boundary so credentials and recurring automation stay bounded." },
+    { name: "Policy boundary", role: "Defines what long-running and recurring actions are permitted; keeps automation deliberate rather than open-ended." },
+    { name: "Logging / inspection", role: "Captures enough state that interrupted work can be inspected and resumed." },
+  ],
+  designDecisions: [
+    { decision: "Split conversation (Hermes) from execution (MALCOM)", rationale: "Keeps the voice/interface layer swappable and the execution layer durable; they fail and evolve independently." },
+    { decision: "Provider-agnostic harness CLI", rationale: "Start and track Codex, OpenCode, Cursor, or a plain terminal through one surface so a provider change does not rewrite the controller." },
+    { decision: "Constrained adapters for services", rationale: "GitHub/Notion/Linear access is deliberately bounded so credentials and scheduled automation cannot run open-ended." },
+    { decision: "Session registry as source of truth", rationale: "Recoverability and inspection require a durable record of what ran, where, and with what workspace." },
+  ],
+  status: "In progress (June 2026 – Present). Active personal tooling; the portfolio surface is intentionally thin and evolves as the project reaches milestones.",
+  limitations: [
+    "No public demo or source repository is linked; this is personal infrastructure, not a shipped product.",
+    "Architecture detail documented publicly is limited by design — most internals are owner-known and not fully described on the portfolio page.",
+    "Single-operator scope: no multi-tenant or shared-access story.",
+    "Hermes (the conversational layer) is mentioned but not part of this pack's scope.",
+  ],
+  technologies: ["Python", "CLI Design", "Agent Orchestration", "GitHub", "Notion", "Linear"],
+  links: [],
+  visualVocabulary: [
+    { token: "Primary blue", usage: "Control-plane surfaces, headers", value: "#1d4ed8" },
+    { token: "Cyan accent", usage: "Adapters, runtime, data flow", value: "#0891b2" },
+    { token: "Robot emoji", usage: "Brand mark", value: "🤖" },
+    { token: "Layered/control-plane motif", usage: "Depict Hermes above MALCOM above the Mac runtime and adapters" },
+  ],
+  diagramPatterns: [
+    {
+      name: "Orchestrator/executor split",
+      description: "Two stacked layers: Hermes (conversation) above MALCOM (execution), with MALCOM fanning out to the Mac runtime and adapters.",
+      nodes: ["Hermes (conversational orchestrator)", "MALCOM (control layer)", "Mac runtime", "GitHub / Notion / Linear adapters"],
+      style: "Stacked layers with downward fan-out to service adapters. Use the blue→cyan palette and solid arrows for control, dashed for data.",
+    },
+    {
+      name: "Session registry hub",
+      description: "Central registry node connected to live harness sessions pointing at isolated workspaces.",
+      nodes: ["Session registry", "Codex session", "OpenCode session", "Cursor session", "Manual shell", "Workspaces"],
+      style: "Hub-and-spoke; registry at center, harnesses as spokes, each linking to its worktree.",
+    },
+    {
+      name: "Provider-agnostic harness lane",
+      description: "A single CLI lane that branches into interchangeable harness providers.",
+      nodes: ["Stable CLI", "Codex", "OpenCode", "Cursor", "Manual terminal"],
+      style: "One input lane fanning into parallel, interchangeable provider branches.",
+    },
+  ],
+  relationships: [
+    { toProject: "Dispatch", relation: "Shared theme (agent orchestration) but different scope: MALCOM is a personal remote-host controller; Dispatch is a local-first collaborative control plane for many agents. MALCOM is single-operator; Dispatch is multi-agent-workspace." },
+    { toProject: "FlowState", relation: "Conceptual lineage: FlowState explored agent context, autonomy, and approval-gating; MALCOM applies similar control/inspection thinking to a durable execution layer." },
+  ],
+  followUpQA: [
+    { question: "Is MALCOM the same as the chat assistant I talk to?", answer: "No. Hermes is the conversational orchestrator you talk to; MALCOM is the execution control layer that actually runs and tracks work on the remote Mac." },
+    { question: "Can I see the code?", answer: "There is no public repository linked; MALCOM is personal infrastructure, not an open product." },
+    { question: "Which coding agents does it control?", answer: "Manual shells plus Codex, OpenCode, and Cursor, through one provider-agnostic CLI." },
+    { question: "How is it different from Dispatch?", answer: "MALCOM controls one operator's remote Mac host; Dispatch runs many agents in a local-first, browser-paired, worktree-isolated workspace for collaborative work." },
+  ],
+  brandColor: "#1d4ed8",
+  accentColor: "#0891b2",
+  emoji: "🤖",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/orca-mail.ts
+++ b/src/data/knowledge-packs/orca-mail.ts
@@ -1,0 +1,77 @@
+import type { KnowledgePack } from "./schema";
+
+export const orcaMailPack: KnowledgePack = {
+  slug: "orca-mail",
+  title: "Orca Mail",
+  summary:
+    "A human-first email client built for the conversations that matter — read-only Gmail, Human Signal, attention views, and a distraction-free Zen writer.",
+  purpose:
+    "Cut through automated inbox noise to surface the messages actually written by people, and give writing a calm, focused surface. Orca connects to Gmail through read-only OAuth and normalizes mail into a clean internal model so the product is not glued to one provider.",
+  intendedUser:
+    "People overwhelmed by automated marketing and inbox clutter who want to read and reply to human-written conversations with focus, without surrendering write access to a third-party tool.",
+  architecture:
+    "Read-only Google OAuth pulls mail in; a normalizer maps provider-specific Gmail messages into a clean internal model designed to extend to Outlook later. Human Signal filters messages to foreground ones written by people. Contact signatures and configurable attention views make conversations scannable. Writing happens in a dedicated full-screen Zen Mode. The app is a Bun monorepo: a React/Vite web app, a Hono API, shared Zod schemas, and SQLite persistence through Drizzle.",
+  components: [
+    { name: "Read-only OAuth connector", role: "Connects to Gmail with read-only OAuth; no write access granted to Orca." },
+    { name: "Mail normalizer", role: "Maps provider-specific messages into a clean internal model, provider-agnostic by design." },
+    { name: "Human Signal filter", role: "Foregrounds messages written by people; filters marketing automation and inbox clutter out of the core reading experience." },
+    { name: "Contact signatures", role: "Per-contact identity metadata to make conversations scannable and recognizable." },
+    { name: "Attention views", role: "Configurable views that focus reading on what matters." },
+    { name: "Zen Mode", role: "Full-screen, distraction-free writer for replies and drafts." },
+    { name: "Hono API + Drizzle/SQLite", role: "Backend API and local persistence for the normalized mail model." },
+  ],
+  designDecisions: [
+    { decision: "Read-only OAuth", rationale: "Privacy and safety first: Orca can read and surface mail but cannot send or alter messages on the user's behalf." },
+    { decision: "Provider-agnostic internal model", rationale: "Normalizing into a clean model means Gmail support now and Outlook later without rewriting the reading/writing surfaces." },
+    { decision: "Human Signal as a first-class filter", rationale: "The core differentiator is surfacing human-written messages rather than ranking all mail." },
+    { decision: "Bun monorepo with shared Zod schemas", rationale: "One schema source shared across the React/Vite app and Hono API keeps the client and server in sync." },
+    { decision: "Dedicated Zen Mode for writing", rationale: "Replies deserve a focused, full-screen surface separate from the scanning inbox." },
+  ],
+  status: "In progress (July 2026 – Present). Active development; Gmail is the first provider, Outlook is planned.",
+  limitations: [
+    "Only Gmail is connected so far; Outlook support is designed-for but not yet implemented.",
+    "No public demo or source repository is linked.",
+    "Read-only: it surfaces and helps draft, but does not send mail through the Gmail account.",
+  ],
+  technologies: ["TypeScript", "React", "Gmail API", "OAuth 2.0", "SQLite", "Drizzle"],
+  links: [],
+  visualVocabulary: [
+    { token: "Primary teal", usage: "Brand, primary surfaces", value: "#0f766e" },
+    { token: "Blue accent", usage: "Data/attention views", value: "#0369a1" },
+    { token: "Calm/wide-spaces motif", usage: "Reflect Zen Mode and distraction-free reading" },
+    { token: "Human-vs-automation contrast", usage: "Depict Human Signal separating human mail from automated clutter" },
+  ],
+  diagramPatterns: [
+    {
+      name: "OAuth → normalize → model → views",
+      description: "Mail flows from read-only Gmail OAuth through a normalizer into the internal model, then into attention views and Zen Mode.",
+      nodes: ["Gmail (read-only OAuth)", "Normalizer", "Internal mail model", "Human Signal filter", "Attention views", "Zen writer"],
+      style: "Left-to-right pipeline; human-written messages branch upward through Human Signal while automation is filtered off the main path. Teal for control, blue for data.",
+    },
+    {
+      name: "Human Signal split",
+      description: "Incoming mail splits into human-written (surfaced) vs automated (filtered) streams.",
+      nodes: ["All mail", "Human Signal", "Human-written (surfaced)", "Automation (filtered)"],
+      style: "A diverging split; surfaced stream emphasized, filtered stream de-emphasized.",
+    },
+    {
+      name: "Provider-agnostic model",
+      description: "Gmail and (future) Outlook both map into one internal model.",
+      nodes: ["Gmail", "Outlook (planned)", "Internal model", "Reading/writing surfaces"],
+      style: "Two provider inputs converging through a normalizer into one model feeding the UI.",
+    },
+  ],
+  relationships: [
+    { toProject: "FlowState", relation: "Thematic link: both engage Gmail/Calendar and aim to reduce noise and protect focus; FlowState planned around it, Orca owns email specifically." },
+    { toProject: "MALCOM", relation: "No direct integration; both are personal-tooling projects that emphasize inspectable, bounded automation." },
+  ],
+  followUpQA: [
+    { question: "Can Orca send email for me?", answer: "No. It uses read-only OAuth, so it surfaces and helps you draft replies, but cannot send or alter messages on your account." },
+    { question: "Does it support Outlook?", answer: "Not yet — the internal model is provider-agnostic by design, but Gmail is the first connected provider." },
+    { question: "What is Human Signal?", answer: "A filter that foregrounds messages written by people and pushes marketing automation and inbox clutter out of the core reading experience." },
+    { question: "Is there a public demo?", answer: "No public demo or source link is published yet." },
+  ],
+  brandColor: "#0f766e",
+  accentColor: "#0369a1",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/personal-website.ts
+++ b/src/data/knowledge-packs/personal-website.ts
@@ -1,0 +1,84 @@
+import type { KnowledgePack } from "./schema";
+
+export const personalWebsitePack: KnowledgePack = {
+  slug: "website",
+  title: "Personal Website",
+  summary:
+    "The living portfolio and publishing space Luke uses to document projects, write about what he is learning, and experiment with thoughtful web interactions — including client-side AI via WebLLM.",
+  purpose:
+    "Be a living portfolio and publishing surface: document projects honestly, publish writing about what is being learned, and use the site itself as a place to experiment with thoughtful web interactions and client-side AI without a server dependency.",
+  intendedUser:
+    "Visitors evaluating Luke's work (recruiters, collaborators, friends) and Luke himself as the author and maintainer of the portfolio, blog, and experiments.",
+  architecture:
+    "A Next.js (App Router) + TypeScript site styled with Tailwind CSS and shadcn/Radix primitives, deployed on Vercel. Project and blog content is authored in data files and generated/normalized through scripts (e.g. a tsx-based blog generator pulling from Notion). Images route through an image-proxy API. Client-side AI experiments run via @mlc-ai/web-llm in the browser so no server model dependency is required. The site also hosts dev-only surfaces (e.g. the knowledge-packs viewer) gated to non-production.",
+  components: [
+    { name: "Next.js App Router frontend", role: "Renders portfolio, blog, projects, and experiment pages." },
+    { name: "Data-authored content", role: "Projects and content live in data files (e.g. src/data/projects.ts) so updates don't require code logic changes." },
+    { name: "Blog generator scripts", role: "tsx scripts generate/normalize blog posts (including from Notion) into site content." },
+    { name: "Image proxy API", role: "Routes images through a server endpoint to handle domain/CORS and resizing concerns." },
+    { name: "WebLLM experiments", role: "Client-side AI via @mlc-ai/web-llm loads models in the browser with no server dependency." },
+    { name: "Tailwind + Radix/shadcn UI", role: "Design system primitives for consistent, accessible UI." },
+    { name: "Vercel deployment", role: "Hosts the site and API routes with preview/production environments." },
+  ],
+  designDecisions: [
+    { decision: "Content as data files, not a CMS", rationale: "Keeping project/blog content in authored data files means updates are reviewable in git and don't require a CMS or database." },
+    { decision: "Next.js App Router + TypeScript", rationale: "Modern React server/client split with type safety across the site and API routes." },
+    { decision: "Client-side AI via WebLLM", rationale: "Experiments run in the visitor's browser — no server model costs, no API key exposure, and it demonstrates what's possible locally." },
+    { decision: "Tailwind + shadcn/Radix", rationale: "Utility-first styling with accessible primitives; fast iteration without a bespoke design system." },
+    { decision: "Dev-only surfaces gated to non-production", rationale: "Viewer/lab tools (e.g. canvas contract lab, knowledge-packs viewer) are hidden in production and shown only in dev/preview so experiments can be inspected safely." },
+    { decision: "Image proxy over direct hotlinking", rationale: "Routing images through a server proxy handles CORS, domain restrictions, and resizing consistently." },
+  ],
+  status: "Completed and live at luke.brevoort.com — continuously evolving as the living portfolio and publishing space.",
+  limitations: [
+    "Content is data-authored, so a non-developer author would need git access to publish.",
+    "WebLLM experiments are bounded by the visitor's device and browser model support; they are demonstrations, not production features.",
+    "Dev-only surfaces are intentionally not part of the public site.",
+    "Blog generation pipeline depends on Notion/external sources staying stable.",
+  ],
+  technologies: ["TypeScript", "Vercel", "GitHub Actions", "WebLLM", "Next.js", "Tailwind CSS"],
+  links: [
+    { label: "Live site", url: "https://luke.brevoort.com/" },
+    { label: "Source", url: "https://github.com/lukebrevoort/website" },
+  ],
+  visualVocabulary: [
+    { token: "Primary blue", usage: "Brand, links, primary surfaces", value: "#3b82f6" },
+    { token: "Violet accent", usage: "Secondary highlights, experiments", value: "#8b5cf6" },
+    { token: "Living/growing motif", usage: "Depict the site as evolving — projects gain pages, blog grows over time" },
+    { token: "Browser-AI glyph", usage: "Represent WebLLM running models client-side without a server" },
+  ],
+  diagramPatterns: [
+    {
+      name: "Data-authored content flow",
+      description: "Content authored in data files flows into the Next.js frontend without a CMS.",
+      nodes: ["Data files (projects.ts, blog)", "Blog generator scripts", "Next.js App Router", "Visitor browser"],
+      style: "Left-to-right: authored data → generated content → rendered site; emphasize no CMS in the path.",
+    },
+    {
+      name: "Client-side AI loop",
+      description: "WebLLM loads a model in the browser and runs AI experiments with no server dependency.",
+      nodes: ["Visitor browser", "WebLLM (@mlc-ai/web-llm)", "Local model", "AI experiment UI"],
+      style: "A self-contained loop inside the browser node; no arrow out to a model server.",
+    },
+    {
+      name: "Dev-only gating",
+      description: "Lab/viewer surfaces are gated to non-production; production traffic never sees them.",
+      nodes: ["Production visitors", "Dev/preview visitors", "Knowledge-packs viewer", "Canvas contract lab"],
+      style: "A gate node split: production path bypasses the dev surfaces; dev/preview path reaches them.",
+    },
+  ],
+  relationships: [
+    { toProject: "MALCOM", relation: "The site documents MALCOM at the portfolio level; the knowledge-packs system on this site carries the richer authored agent context for MALCOM." },
+    { toProject: "Dispatch", relation: "Dispatch is documented on this site as a featured project; the site's knowledge-pack for Dispatch carries the authored agent context alongside the portfolio page." },
+    { toProject: "Orca Mail", relation: "Orca Mail is documented on this site as a featured project; the site's knowledge-pack mirrors and deepens that portfolio content for agent use." },
+    { toProject: "FlowState", relation: "FlowState has a dedicated rich page on this site; its knowledge-pack reflects that same authored content for the visual agent." },
+  ],
+  followUpQA: [
+    { question: "Is the site itself the product, or a portfolio?", answer: "Both — it is the living portfolio and publishing space, and it doubles as a place to experiment with web interactions and client-side AI." },
+    { question: "How is content published?", answer: "Projects and blog content are authored in data files and generated through scripts, so publishing is a git-reviewed change rather than a CMS action." },
+    { question: "Do the AI experiments need a server?", answer: "No — they run client-side via @mlc-ai/web-llm in the visitor's browser, with no server model dependency or API key exposure." },
+    { question: "Are there hidden dev-only pages?", answer: "Yes — lab/viewer surfaces (canvas contract lab, knowledge-packs viewer) are gated to non-production and shown only in dev or Vercel preview." },
+  ],
+  brandColor: "#3b82f6",
+  accentColor: "#8b5cf6",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/schema.ts
+++ b/src/data/knowledge-packs/schema.ts
@@ -1,0 +1,69 @@
+export interface KnowledgePackComponent {
+  name: string;
+  role: string;
+}
+
+export interface KnowledgePackDesignDecision {
+  decision: string;
+  rationale: string;
+}
+
+export interface KnowledgePackLink {
+  label: string;
+  url: string;
+}
+
+export interface VisualToken {
+  token: string;
+  usage: string;
+  value?: string;
+}
+
+export interface DiagramPattern {
+  name: string;
+  description: string;
+  nodes: string[];
+  style: string;
+}
+
+export interface KnowledgePackRelationship {
+  toProject: string;
+  relation: string;
+}
+
+export interface FollowUpQA {
+  question: string;
+  answer: string;
+}
+
+export interface KnowledgePack {
+  slug: string;
+  title: string;
+  summary: string;
+  purpose: string;
+  intendedUser: string;
+  architecture: string;
+  components: KnowledgePackComponent[];
+  designDecisions: KnowledgePackDesignDecision[];
+  status: string;
+  limitations: string[];
+  technologies: string[];
+  links: KnowledgePackLink[];
+  visualVocabulary: VisualToken[];
+  diagramPatterns: DiagramPattern[];
+  relationships: KnowledgePackRelationship[];
+  followUpQA: FollowUpQA[];
+  brandColor: string;
+  accentColor: string;
+  emoji?: string;
+  lastAuthored: string;
+}
+
+export const knowledgePackSlugs = [
+  "malcom",
+  "dispatch",
+  "orca-mail",
+  "flowstate",
+] as const;
+
+export type KnowledgePackSlug = (typeof knowledgePackSlugs)[number];

--- a/src/data/knowledge-packs/schema.ts
+++ b/src/data/knowledge-packs/schema.ts
@@ -64,6 +64,12 @@ export const knowledgePackSlugs = [
   "dispatch",
   "orca-mail",
   "flowstate",
+  "canvas-notion",
+  "hftc",
+  "zen80",
+  "while-unemployed",
+  "sga-finance",
+  "website",
 ] as const;
 
 export type KnowledgePackSlug = (typeof knowledgePackSlugs)[number];

--- a/src/data/knowledge-packs/sga-finance.ts
+++ b/src/data/knowledge-packs/sga-finance.ts
@@ -1,0 +1,77 @@
+import type { KnowledgePack } from "./schema";
+
+export const sgaFinancePack: KnowledgePack = {
+  slug: "sga-finance",
+  title: "SGA Finance Platform",
+  summary:
+    "A document-automation platform for Stevens SGA Finance that turns CampusGroups exports into review-ready weekly spreadsheets and Senate-ready budget-request presentations — now handling over $2.5M.",
+  purpose:
+    "Remove manual spreadsheet and slide labor from SGA Finance by converting CampusGroups exports into review-ready weekly spreadsheets and Senate-ready budget-request presentations automatically, so finance review happens on numbers instead of formatting.",
+  intendedUser:
+    "Stevens SGA Finance reviewers and the Senate budget process — the people who need fast, consistent weekly financial review and presentable budget-request decks.",
+  architecture:
+    "A Next.js + TypeScript frontend (Tailwind, Vercel-hosted) drives the document-automation flows. CampusGroups exports are ingested and mapped into structured financial data, then rendered to Google Sheets for weekly review spreadsheets and Google Slides for Senate-ready budget-request presentations. Automation replaces the manual formatting step; Google Sheets/Slides are the output surfaces, not human-formatting targets.",
+  components: [
+    { name: "CampusGroups import", role: "Ingests CampusGroups exports that previously drove manual formatting." },
+    { name: "Financial data model", role: "Normalizes exports into structured data that weekly sheets and budget decks are generated from." },
+    { name: "Google Sheets renderer", role: "Produces review-ready weekly spreadsheets from the normalized data." },
+    { name: "Google Slides renderer", role: "Produces Senate-ready budget-request presentations." },
+    { name: "Next.js web app", role: "Operator UI for running the document-automation flows." },
+    { name: "Vercel deployment", role: "Hosts the app with simple access for SGA Finance." },
+  ],
+  designDecisions: [
+    { decision: "Automate formatting, not judgment", rationale: "Reviewers should spend time on the numbers, not formatting spreadsheets and slides; the platform replaces the formatting labor." },
+    { decision: "Google Sheets + Slides as output surfaces", rationale: "SGA already worked in Google Workspace; generating into Sheets and Slides meets reviewers where they are instead of forcing a new tool." },
+    { decision: "CampusGroups exports as the input", rationale: "CampusGroups was the source of student-org financial data; accepting its exports removes the manual copy-paste step." },
+    { decision: "Web app over a scheduled batch job", rationale: "Finance review cadence varies; an operator-run web flow gives control over when outputs are produced." },
+    { decision: "Next.js + Vercel hosting", rationale: "Fast delivery and simple access for an internal university tool." },
+  ],
+  status: "Completed and working — in production use for Stevens SGA Finance, handling over $2.5M.",
+  limitations: [
+    "CampusGroups-specific input format; a different export schema would require mapping changes.",
+    "Output fidelity is bounded by the Google Sheets/Slides APIs; highly custom layouts may not be fully automatable.",
+    "Internal university tool — the deployment and access are scoped to SGA Finance.",
+    "Not a general finance platform; the model is tuned to SGA's review and Senate budget flows.",
+  ],
+  technologies: ["Next.js", "TypeScript", "Vercel", "Google Sheets", "Google Slides", "Automation"],
+  links: [
+    { label: "Source", url: "https://github.com/lukebrevoort/sga-finance-platform" },
+    { label: "Demo", url: "https://sga-finance-platorm.vercel.app" },
+  ],
+  visualVocabulary: [
+    { token: "Primary green", usage: "Finance, approval, healthy balances", value: "#16a34a" },
+    { token: "Near-black accent", usage: "Senate/formal documents, structure", value: "#0f172a" },
+    { token: "Document-generation motif", usage: "Depict one input (CampusGroups export) fanning into two outputs (Sheets + Slides)" },
+    { token: "Dollar/money glyph", usage: "Represent the $2.5M+ scale handled by the platform" },
+  ],
+  diagramPatterns: [
+    {
+      name: "One input, two outputs",
+      description: "CampusGroups export fans into a review-ready weekly Google Sheet and a Senate-ready Google Slides deck.",
+      nodes: ["CampusGroups export", "Financial data model", "Google Sheets (weekly review)", "Google Slides (Senate budget)"],
+      style: "A single input node fanning into two output surfaces via the data model. Green for finance/approval, near-black for Senate/formal outputs.",
+    },
+    {
+      name: "Format-removal pipeline",
+      description: "The platform replaces manual formatting: data in → formatted Sheets/Slides out.",
+      nodes: ["Manual formatting (replaced)", "CampusGroups import", "Data model", "Generated Sheets/Slides"],
+      style: "A struck-through manual-formatting node replaced by the automation pipeline.",
+    },
+    {
+      name: "Scale annotation",
+      description: "The platform is annotated as handling over $2.5M, emphasizing production use over a demo.",
+      nodes: ["SGA Finance Platform", "$2.5M+ handled", "Weekly reviews", "Senate budget decks"],
+      style: "A central platform node with a scale annotation and its two outputs.",
+    },
+  ],
+  relationships: [],
+  followUpQA: [
+    { question: "Is this actually used?", answer: "Yes — it is in production for Stevens SGA Finance and handles over $2.5M." },
+    { question: "Where does the data come from?", answer: "CampusGroups exports — the platform replaces the manual copy-paste/format step that used to turn them into review spreadsheets." },
+    { question: "Why Google Sheets and Slides?", answer: "SGA already worked in Google Workspace; generating into Sheets and Slides meets reviewers where they are instead of forcing a new tool." },
+    { question: "Is the source public?", answer: "Yes — on GitHub at github.com/lukebrevoort/sga-finance-platform, with a demo deployment on Vercel." },
+  ],
+  brandColor: "#16a34a",
+  accentColor: "#0f172a",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/while-unemployed.ts
+++ b/src/data/knowledge-packs/while-unemployed.ts
@@ -1,0 +1,77 @@
+import type { KnowledgePack } from "./schema";
+
+export const whileUnemployedPack: KnowledgePack = {
+  slug: "while-unemployed",
+  title: "while_unemployed",
+  summary:
+    "A completed class MVP for technical-interview practice, pairing an AI interviewer, live code analysis, and voice interaction; the MVP and demo earned a 100% evaluation.",
+  purpose:
+    "Give technical-interview candidates a realistic practice loop: an AI interviewer asks questions, analyzes live code, and converses by voice — turning passive interview prep into a simulated, interactive conversation that can be evaluated.",
+  intendedUser:
+    "Developers preparing for technical interviews who want a mock interviewer that reacts to their code and answers in real time, not just a question bank.",
+  architecture:
+    "A Next.js + TypeScript frontend (Tailwind CSS) hosts the candidate experience. A FastAPI backend hosts the AI interviewer logic and OpenAI integration. Socket.IO carries live conversation and code-analysis events between client and server so the interviewer can react as the candidate types and speaks. Supabase backs persistence and auth. The build earned a 100% evaluation as a class MVP.",
+  components: [
+    { name: "Next.js candidate UI", role: "Frontend for the interview session: code editor, prompts, and voice interaction." },
+    { name: "FastAPI interviewer backend", role: "Hosts the AI interviewer logic and OpenAI calls on the server." },
+    { name: "OpenAI integration", role: "Powers question generation, response evaluation, and the conversational interviewer." },
+    { name: "Socket.IO live channel", role: "Streams conversation and live code-analysis events so the interviewer reacts in real time." },
+    { name: "Supabase persistence/auth", role: "Stores sessions and handles authentication." },
+    { name: "Voice interaction", role: "Lets the candidate speak with the interviewer rather than only typing." },
+  ],
+  designDecisions: [
+    { decision: "AI interviewer over a question bank", rationale: "Real prep needs reactive follow-ups and pushback on answers; a static bank cannot simulate that." },
+    { decision: "Live code analysis via Socket.IO", rationale: "The interviewer should react as the candidate writes — not only after submission — which needs streaming events." },
+    { decision: "Voice interaction included", rationale: "Spoken interviews are a different skill than written ones; including voice made the practice more realistic." },
+    { decision: "FastAPI + OpenAI on the backend", rationale: "Keeps the API key server-side and lets Python host the interviewer orchestration cleanly." },
+    { decision: "Next.js + Supabase for the frontend", rationale: "Fast UI delivery plus lightweight persistence/auth for a class MVP scope." },
+  ],
+  status: "Completed (2025). Class MVP; the demo earned a 100% evaluation.",
+  limitations: [
+    "MVP scope: interview richness is bounded by a single OpenAI-backed interviewer flow, not a platform of mock interviewers.",
+    "Class project — not maintained as a product; no active user base.",
+    "Live code analysis depends on Socket.IO reliability and OpenAI latency; not tuned for scale.",
+    "Voice interaction adds complexity that an MVP-grade deployment may not harden.",
+  ],
+  technologies: ["Next.js", "TypeScript", "Tailwind CSS", "FastAPI", "Socket.IO", "Supabase", "OpenAI"],
+  links: [
+    { label: "Source", url: "https://github.com/lukebrevoort/while_unemployed" },
+    { label: "Demo", url: "https://while-unemployed.vercel.app" },
+  ],
+  visualVocabulary: [
+    { token: "Primary near-black", usage: "Editor/interviewer surfaces", value: "#0f172a" },
+    { token: "Sky-blue accent", usage: "Live events, voice, AI responses", value: "#0284c7" },
+    { token: "Conversation loop motif", usage: "Depict candidate ↔ AI interviewer as a real-time loop, not one-shot Q&A" },
+    { token: "Live code-analysis glyph", usage: "Represent the editor streaming analysis to the interviewer" },
+  ],
+  diagramPatterns: [
+    {
+      name: "Real-time interview loop",
+      description: "Candidate ↔ AI interviewer with code and voice flowing over Socket.IO in a live loop.",
+      nodes: ["Candidate UI (Next.js)", "Socket.IO channel", "FastAPI interviewer", "OpenAI"],
+      style: "Bidirectional loop between client and server; code editor and voice feed into the channel, OpenAI drives the interviewer's replies.",
+    },
+    {
+      name: "Live code analysis",
+      description: "As the candidate types, code is streamed to the backend and the interviewer reacts.",
+      nodes: ["Code editor", "Socket.IO", "Live code analysis", "AI interviewer reaction"],
+      style: "Streaming arrow from editor → backend → interviewer reaction, emphasizing the in-flight (not post-submit) analysis.",
+    },
+    {
+      name: "Voice + code session",
+      description: "A session combines spoken answers and live coding in one experience.",
+      nodes: ["Voice input", "Code editor", "Interviewer (AI)", "Session state (Supabase)"],
+      style: "Two inputs (voice + code) converging on the interviewer, with session state persisted.",
+    },
+  ],
+  relationships: [],
+  followUpQA: [
+    { question: "Did it pass the class?", answer: "Yes — the MVP and demo earned a 100% evaluation." },
+    { question: "Is there a live demo?", answer: "Yes, deployed at while-unemployed.vercel.app, with source on GitHub." },
+    { question: "Why a live interviewer instead of a question bank?", answer: "Real interviews are reactive — the interviewer follows up and pushes back. A static bank cannot simulate that, so the MVP streams code and voice to the AI interviewer in real time." },
+    { question: "Is it still maintained?", answer: "No — it is a completed class MVP, not an active product." },
+  ],
+  brandColor: "#0f172a",
+  accentColor: "#0284c7",
+  lastAuthored: "2026-07-20",
+};

--- a/src/data/knowledge-packs/zen80.ts
+++ b/src/data/knowledge-packs/zen80.ts
@@ -1,0 +1,79 @@
+import type { KnowledgePack } from "./schema";
+
+export const zen80Pack: KnowledgePack = {
+  slug: "zen80",
+  title: "Zen80",
+  summary:
+    "A completed Flutter productivity tracker built around Signal vs. Noise: choose the few tasks that matter, protect time for them on the calendar, and measure whether the day matched that intent.",
+  purpose:
+    "Help a person identify the few important tasks (Signal) amid the noise of a busy day, protect calendar time for them, and then honestly measure whether the day matched the intended focus — turning intent into a measurable signal-to-noise ratio for how the day was spent.",
+  intendedUser:
+    "Luke as a personal app today. Originally: individuals who want their daily planning to be about protecting the few things that matter, not listing everything.",
+  architecture:
+    "A Flutter app with Dart persists locally via Hive and manages state through Provider. Google Calendar API integration lets protected time blocks land on the calendar. OAuth2 authorizes calendar access. The core model is Signal vs. Noise: a small number of important tasks (Signal) versus the churn of the day (Noise), with the app measuring the ratio of how time was actually spent against intent.",
+  components: [
+    { name: "Signal vs. Noise model", role: "Core abstraction: a few important tasks (Signal) vs. daily churn (Noise), measured as a ratio of intent-to-actual time." },
+    { name: "Task selection surface", role: "Lets the user pick the handful of tasks that matter for the day." },
+    { name: "Calendar protection", role: "Google Calendar API blocks protected time for those Signal tasks so they are defended against the noise." },
+    { name: "Day-match measurement", role: "Measures whether the day matched intent — the actual time-vs-intent ratio." },
+    { name: "Local persistence (Hive)", role: "Dart/Flutter local store for tasks and history without a backend." },
+    { name: "Provider state management", role: "Reactive app state for the task/day model." },
+    { name: "OAuth2 calendar auth", role: "Authorizes read/write to Google Calendar for time blocking." },
+  ],
+  designDecisions: [
+    { decision: "Signal vs. Noise as the core model", rationale: "Most productivity apps list everything; Zen80 makes the user pick the few that matter and measures the day against that choice — a clearer signal of focus than completion counts." },
+    { decision: "Protect time on the calendar", rationale: "Intent without protected time loses; placing blocks on Google Calendar defends Signal tasks against Noise." },
+    { decision: "Measure intent vs. actual", rationale: "A good day is not 'did everything' — it is 'spent time on what I said mattered'. Measuring that ratio is more honest than task completion." },
+    { decision: "Local-first via Hive", rationale: "A personal app should not require a backend; local persistence keeps it private and fast." },
+    { decision: "Flutter + Provider", rationale: "Cross-platform personal tooling with a simple reactive state model." },
+  ],
+  status: "Completed. Now a personal app — Luke uses it day-to-day; not a maintained/shipped product.",
+  limitations: [
+    "Personal app: no public distribution or multi-user story.",
+    "Google Calendar is the only integration; no general task-source sync.",
+    "Local-first means no cloud sync/history portability beyond the device.",
+    "Measurement is self-reported intent vs. calendar reality — it does not auto-detect what attention actually went to.",
+  ],
+  technologies: ["Flutter", "Dart", "Google Calendar API", "Hive", "Provider", "OAuth2"],
+  links: [{ label: "Source", url: "https://github.com/lukebrevoort/Zen80" }],
+  visualVocabulary: [
+    { token: "Primary teal", usage: "Signal, important tasks, focus", value: "#0f766e" },
+    { token: "Blue accent", usage: "Calendar protection, planned time", value: "#2563eb" },
+    { token: "Signal-vs-noise contrast motif", usage: "A few bold Signal items against a faded field of Noise" },
+    { token: "Calendar-block glyph", usage: "Depict protected time blocks on the calendar" },
+    { token: "Ratio/meter glyph", usage: "Depict the intent-vs-actual ratio that defines a good day" },
+  ],
+  diagramPatterns: [
+    {
+      name: "Signal vs. Noise",
+      description: "A small set of Signal tasks stands apart from a larger faded field of Noise; the day is measured by the ratio.",
+      nodes: ["Signal tasks (few)", "Noise (many, faded)", "Intent", "Day-match ratio"],
+      style: "A few bold nodes against a faded background; a meter/ratio node comparing intent to actual.",
+    },
+    {
+      name: "Select → protect → measure",
+      description: "Pick the Signal tasks, protect them on the calendar, then measure the day against intent.",
+      nodes: ["Task selection", "Calendar protection (Google Calendar)", "Day-match measurement"],
+      style: "Left-to-right pipeline; selection feeds calendar blocking feeds the end-of-day ratio.",
+    },
+    {
+      name: "Calendar time-block",
+      description: "A Signal task becomes a protected time block on Google Calendar.",
+      nodes: ["Signal task", "OAuth2", "Google Calendar", "Protected time block"],
+      style: "A task node flowing through OAuth2 into a calendar with a blocked-out time region.",
+    },
+  ],
+  relationships: [
+    { toProject: "FlowState", relation: "Shared theme of focus and reducing noise; FlowState orchestrated study context broadly, Zen80 narrows the same instinct to daily Signal-vs-Noise time protection." },
+    { toProject: "Orca Mail", relation: "Thematic kin: both cut through noise (automated mail / daily churn) to protect the human, important thing." },
+  ],
+  followUpQA: [
+    { question: "Is Zen80 still being developed?", answer: "It is complete and Luke uses it as a personal app today; it is not a maintained/shipped product." },
+    { question: "How is Zen80 different from other to-do apps?", answer: "It does not try to track everything. You pick a few Signal tasks, protect time for them on the calendar, and the day is measured against that intent rather than by total completion." },
+    { question: "Does it need a backend?", answer: "No — it is local-first using Hive for persistence; only the Google Calendar integration uses OAuth2." },
+    { question: "Where is the source?", answer: "On GitHub at github.com/lukebrevoort/Zen80." },
+  ],
+  brandColor: "#0f766e",
+  accentColor: "#2563eb",
+  lastAuthored: "2026-07-20",
+};


### PR DESCRIPTION
Closes https://linear.app/brevoort/issue/BRE-145/create-curated-agent-knowledge-packs-for-featured-projects

## What this adds

Authored, structured **knowledge packs** for the four featured projects — MALCOM, Dispatch, Orca Mail, FlowState — covering every section the ticket specifies:

- Purpose and intended user
- System architecture and major components
- Important design decisions (decision + rationale)
- Current status and **honest limitations**
- Technologies and external links
- Visual vocabulary and suggested diagram patterns
- Inter-project relationships
- Answers to likely follow-up questions

Packs are **data files** (`src/data/knowledge-packs/<slug>.ts`), so updating project knowledge does **not** require editing the canvas UI.

## Selection without every project in every prompt

- `buildAgentPromptContext(slug)` renders one project's pack into a markdown context string for a model.
- `GET /api/knowledge-packs` lists summaries; `GET /api/knowledge-packs/<slug>` returns the full pack **and** the pre-rendered agent prompt for that one project.
- An agent fetches only the active project's slug — never all four projects.

## Starter diagrams and dynamic generation use the same facts

Both read the single authored `architecture`/`components`/`diagramPatterns` source; there is no separate diagram fact base to drift from.

## Local testing

- **Dev-only viewer:** `npm run dev` → http://localhost:3000/knowledge-packs
  - Pack tab: inspect every section of the selected project.
  - Agent prompt tab: the exact context a model would receive, with Copy.
  - Gated to non-production (`NODE_ENV !== "production"` or `VERCEL_ENV === "preview"`), mirroring the BRE-143 canvas lab convention.
- **API:** `curl /api/knowledge-packs` and `curl /api/knowledge-packs/malcom` (JSON).
- **Verification:** `npx tsc --noEmit`, `eslint` on new files, and `npm run build` all pass.

## Screenshots

- Viewer (MALCOM, pack tab): `~/.local/share/opencode/screenshots/2026-07-20-bre145-viewer-malcom.png`
- Viewer (agent prompt tab): `~/.local/share/opencode/screenshots/2026-07-20-bre145-agent-prompt.png`

## Files

- `src/data/knowledge-packs/` — schema, four packs, registry/loader
- `src/app/api/knowledge-packs/` — JSON API (list + per-pack)
- `src/app/knowledge-packs/` + `knowledge-pack-viewer.tsx` — dev-only viewer
- `scripts/ingest-malcom-chats.ts` — opt-in offline scrubbing/indexing script for Malcolm chat exports
- `docs/handoffs/BRE-145-knowledge-packs.md` — handoff + integration guidance

## On the Tailscale/Malcolm idea

opencode has no network path to Malcolm from this environment, so I did **not** ingest chats here. Instead `scripts/ingest-malcom-chats.ts` is an opt-in, offline script to run from a host that can reach Malcolm (the Mac it runs on, or a machine on the same Tailnet): it reads exported chat files, scrubs API keys/tokens/passwords/emails/phones/credit-cards/private keys/AWS creds, and writes a scrubbed chunk index plus a keyword index. It does **not** embed by default (no embeddings dependency added), and the handoff doc documents where to plug in an embeddings provider. **Always review the scrubbed output before exposing it to a model.**

```
tsx scripts/ingest-malcom-chats.ts --input <exported-chats-dir> --output .private/malcom-index.jsonl
```

## Integration follow-up (on `homepage-canvas`)

Wiring into the vision-agent request flow (BRE-144 and beyond): fetch the active project's pack and prepend `buildAgentPromptContext(slug)` to the Gemini request, keeping the existing `CanvasPatchV1 → validate → compile → confirm → apply` sequence unchanged.